### PR TITLE
Simplify locked write strategy in FileArrayWriter

### DIFF
--- a/Classes/Pattern/FileArrayPatternBackend.php
+++ b/Classes/Pattern/FileArrayPatternBackend.php
@@ -115,21 +115,26 @@ final class FileArrayPatternBackend implements PatternBackendInterface
 
     public function removeById(string $id): void
     {
-        $data = $this->fileArrayWriter->readArray();
+        $removedPattern = null;
 
-        if (!isset($data[$id])) {
-            return;
+        $this->fileArrayWriter->readModifyWrite(function (array $data) use ($id, &$removedPattern): ?array {
+            if (!isset($data[$id])) {
+                return null;
+            }
+
+            $removedPattern = $data[$id];
+            unset($data[$id]);
+
+            return $data;
+        });
+
+        if ($removedPattern !== null) {
+            $this->logger?->info('Firewall pattern removed', [
+                'id' => $id,
+                'kind' => $removedPattern['kind'] ?? 'unknown',
+                'value' => $removedPattern['value'] ?? 'unknown',
+            ]);
         }
-
-        $removedPattern = $data[$id];
-        unset($data[$id]);
-
-        $this->fileArrayWriter->writeArray($data);
-        $this->logger?->info('Firewall pattern removed', [
-            'id' => $id,
-            'kind' => $removedPattern['kind'] ?? 'unknown',
-            'value' => $removedPattern['value'] ?? 'unknown',
-        ]);
     }
 
     private function generatePatternHash(PatternEntry $patternEntry): string
@@ -141,29 +146,31 @@ final class FileArrayPatternBackend implements PatternBackendInterface
     {
         $this->validatePatternEntry($patternEntry);
 
-        $this->fileArrayWriter->ensureDirectory();
-        $this->fileArrayWriter->ensureFileExists();
-
         $now = $this->now;
-        $data = $this->fileArrayWriter->readArray();
         $id = $patternEntry->metadata['id'] ?? null;
         if (!is_string($id) || $id === '') {
             $id = $this->generatePatternHash($patternEntry);
         }
 
-        $existingRow = $data[$id] ?? null;
+        $wasUpdate = false;
 
-        if ($existingRow === null && count($data) >= self::MAX_ENTRIES) {
-            throw new \RuntimeException(
-                sprintf('Pattern file exceeds maximum entries (%d).', self::MAX_ENTRIES),
-                1770244690
-            );
-        }
+        $this->fileArrayWriter->readModifyWrite(function (array $data) use ($patternEntry, $now, $id, &$wasUpdate): array {
+            $existingRow = $data[$id] ?? null;
 
-        $data[$id] = $this->createRow($patternEntry, $now, $existingRow);
-        $this->fileArrayWriter->writeArray($data);
+            if ($existingRow === null && count($data) >= self::MAX_ENTRIES) {
+                throw new \RuntimeException(
+                    sprintf('Pattern file exceeds maximum entries (%d).', self::MAX_ENTRIES),
+                    1770244690
+                );
+            }
 
-        $this->logger?->info($existingRow !== null ? 'Firewall pattern updated' : 'Firewall pattern added', [
+            $wasUpdate = $existingRow !== null;
+            $data[$id] = $this->createRow($patternEntry, $now, $existingRow);
+
+            return $data;
+        });
+
+        $this->logger?->info($wasUpdate ? 'Firewall pattern updated' : 'Firewall pattern added', [
             'id' => $id,
             'kind' => $patternEntry->kind,
             'value' => $patternEntry->value,
@@ -313,22 +320,31 @@ final class FileArrayPatternBackend implements PatternBackendInterface
 
     public function pruneExpired(): void
     {
-        $data = $this->fileArrayWriter->readArray();
         $now = $this->now;
-        $originalCount = count($data);
+        $prunedCount = 0;
 
-        $data = array_filter($data, static function (array $row) use ($now): bool {
-            $expiresAt = $row['expiresAt'] ?? null;
-            if (!is_scalar($expiresAt)) {
-                return true;
+        $this->fileArrayWriter->readModifyWrite(function (array $data) use ($now, &$prunedCount): ?array {
+            $originalCount = count($data);
+
+            $data = array_filter($data, static function (array $row) use ($now): bool {
+                $expiresAt = $row['expiresAt'] ?? null;
+                if (!is_scalar($expiresAt)) {
+                    return true;
+                }
+
+                return ((int)$expiresAt) > $now;
+            });
+
+            $prunedCount = $originalCount - count($data);
+
+            if ($prunedCount === 0) {
+                return null;
             }
 
-            return ((int)$expiresAt) > $now;
+            return $data;
         });
 
-        $prunedCount = $originalCount - count($data);
         if ($prunedCount > 0) {
-            $this->fileArrayWriter->writeArray($data);
             $this->logger?->info('Expired firewall patterns pruned', ['count' => $prunedCount]);
         }
     }

--- a/Classes/Writer/FileArrayWriter.php
+++ b/Classes/Writer/FileArrayWriter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Flowd\Typo3Firewall\Writer;
 
 use Psr\Log\LoggerInterface;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Handles safe file I/O for pattern array persistence using JSON format.
@@ -116,7 +115,17 @@ final class FileArrayWriter
 
     public function ensureDirectory(): void
     {
-        GeneralUtility::mkdir_deep(dirname($this->filePath));
+        $directory = dirname($this->filePath);
+        if (is_dir($directory)) {
+            return;
+        }
+
+        if (!@mkdir($directory, 0775, true) && !is_dir($directory)) {
+            $this->logger?->warning('Cannot create directory for pattern file', [
+                'path' => $this->filePath,
+                'directory' => $directory,
+            ]);
+        }
     }
 
     /**
@@ -126,28 +135,52 @@ final class FileArrayWriter
      */
     public function writeArray(array $data): void
     {
-        $this->assertScalarData($data);
         $this->ensureDirectory();
 
-        try {
-            $json = json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-        } catch (\JsonException $jsonException) {
-            throw new \RuntimeException(
-                sprintf('Cannot encode pattern data to JSON: %s', $jsonException->getMessage()),
-                1770238500,
-                $jsonException
-            );
-        }
-
-        $tmp = $this->filePath . '.' . bin2hex(random_bytes(16));
+        $lockHandle = $this->acquireExclusiveLock();
 
         try {
-            $this->writeWithLock($tmp, $json);
-            $this->invalidateCaches();
+            $this->writeArrayLocked($data);
         } finally {
-            if (is_file($tmp)) {
-                @unlink($tmp);
+            flock($lockHandle, LOCK_UN);
+            fclose($lockHandle);
+        }
+    }
+
+    /**
+     * Atomically reads, modifies, and writes the array file while holding an exclusive lock.
+     *
+     * The modifier callable receives the current data array and must return either:
+     * - an array: the new data to write
+     * - null: skip writing (no-op signal)
+     *
+     * @param callable(array<string, array<string, mixed>>): (?array<string, array<string, mixed>>) $modifier
+     */
+    public function readModifyWrite(callable $modifier): void
+    {
+        $this->ensureDirectory();
+        $lockHandle = $this->acquireExclusiveLock();
+
+        try {
+            clearstatcache(true, $this->filePath);
+            $data = $this->readArray();
+            $result = $modifier($data);
+
+            if ($result === null) {
+                return;
             }
+
+            if (!is_array($result)) {
+                throw new \LogicException(
+                    sprintf('readModifyWrite modifier must return array|null, got %s', get_debug_type($result)),
+                    1779133201
+                );
+            }
+
+            $this->writeArrayLocked($result);
+        } finally {
+            flock($lockHandle, LOCK_UN);
+            fclose($lockHandle);
         }
     }
 
@@ -177,17 +210,15 @@ final class FileArrayWriter
         $this->logger?->debug('Pattern file written', ['path' => $this->filePath]);
     }
 
-    private function writeWithLock(string $tmpFile, string $content): void
+    /**
+     * Opens the lock file and acquires an exclusive lock.
+     *
+     * @return resource The lock file handle (caller must unlock and close)
+     */
+    private function acquireExclusiveLock(): mixed
     {
-        if (!GeneralUtility::writeFile($tmpFile, $content)) {
-            throw new \RuntimeException(
-                sprintf('Cannot write temporary pattern file: %s', $tmpFile),
-                1770238507
-            );
-        }
-
         $lockFile = $this->filePath . '.lock';
-        $lockHandle = fopen($lockFile, 'c');
+        $lockHandle = fopen($lockFile, 'cb');
         if ($lockHandle === false) {
             throw new \RuntimeException(
                 sprintf('Cannot create lock file: %s', $lockFile),
@@ -195,26 +226,58 @@ final class FileArrayWriter
             );
         }
 
+        if (!flock($lockHandle, LOCK_EX)) {
+            fclose($lockHandle);
+            throw new \RuntimeException(
+                sprintf('Cannot acquire lock for pattern file: %s', $this->filePath),
+                1770238497
+            );
+        }
+
+        return $lockHandle;
+    }
+
+    /**
+     * Writes the array to the file. Assumes caller holds the exclusive lock.
+     *
+     * @param array<string, array<string, mixed>> $data
+     */
+    private function writeArrayLocked(array $data): void
+    {
+        $this->assertScalarData($data);
+
         try {
-            if (!flock($lockHandle, LOCK_EX)) {
+            $json = json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        } catch (\JsonException $jsonException) {
+            throw new \RuntimeException(
+                sprintf('Cannot encode pattern data to JSON: %s', $jsonException->getMessage()),
+                1770238500,
+                $jsonException
+            );
+        }
+
+        $tmp = $this->filePath . '.' . bin2hex(random_bytes(16));
+
+        try {
+            if (file_put_contents($tmp, $json) === false) {
                 throw new \RuntimeException(
-                    sprintf('Cannot acquire lock for pattern file: %s', $this->filePath),
-                    1770238497
+                    sprintf('Cannot write temporary pattern file: %s', $tmp),
+                    1770238507
                 );
             }
 
-            if (!@rename($tmpFile, $this->filePath) && file_put_contents($this->filePath, $content) === false) {
+            if (!@rename($tmp, $this->filePath) && file_put_contents($this->filePath, $json) === false) {
                 throw new \RuntimeException(
                     sprintf('Cannot write pattern file: %s', $this->filePath),
                     1770238512
                 );
             }
 
-            $this->logger?->debug('Pattern file written successfully', ['path' => $this->filePath]);
+            $this->invalidateCaches();
         } finally {
-            flock($lockHandle, LOCK_UN);
-            fclose($lockHandle);
-            @unlink($lockFile);
+            if (is_file($tmp)) {
+                @unlink($tmp);
+            }
         }
     }
 }

--- a/Tests/Unit/Pattern/FileArrayPatternBackendTest.php
+++ b/Tests/Unit/Pattern/FileArrayPatternBackendTest.php
@@ -8,6 +8,7 @@ use Flowd\Phirewall\Pattern\PatternEntry;
 use Flowd\Phirewall\Pattern\PatternKind;
 use Flowd\Typo3Firewall\Pattern\FileArrayPatternBackend;
 use Flowd\Typo3Firewall\Writer\FileArrayWriter;
+use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -23,31 +24,9 @@ final class FileArrayPatternBackendTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->testDir = sys_get_temp_dir() . '/typo3_firewall_backend_test_' . bin2hex(random_bytes(8));
-        @mkdir($this->testDir, 0777, true);
+        vfsStream::setup('root');
+        $this->testDir = vfsStream::url('root');
         $this->testFile = $this->testDir . '/patterns.json';
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-        $this->removeDirectory($this->testDir);
-    }
-
-    private function removeDirectory(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $scanned = scandir($dir);
-        $files = array_diff($scanned !== false ? $scanned : [], ['.', '..']);
-        foreach ($files as $file) {
-            $path = $dir . '/' . $file;
-            is_dir($path) ? $this->removeDirectory($path) : @unlink($path);
-        }
-
-        @rmdir($dir);
     }
 
     private function createBackend(?int $now = null): FileArrayPatternBackend

--- a/Tests/Unit/Writer/FileArrayWriterTest.php
+++ b/Tests/Unit/Writer/FileArrayWriterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flowd\Typo3Firewall\Tests\Unit\Writer;
 
 use Flowd\Typo3Firewall\Writer\FileArrayWriter;
+use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -18,30 +19,8 @@ final class FileArrayWriterTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->testDir = sys_get_temp_dir() . '/typo3_firewall_test_' . bin2hex(random_bytes(8));
-        @mkdir($this->testDir, 0777, true);
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-        $this->removeDirectory($this->testDir);
-    }
-
-    private function removeDirectory(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-
-        $scanned = scandir($dir);
-        $files = array_diff($scanned !== false ? $scanned : [], ['.', '..']);
-        foreach ($files as $file) {
-            $path = $dir . '/' . $file;
-            is_dir($path) ? $this->removeDirectory($path) : @unlink($path);
-        }
-
-        @rmdir($dir);
+        vfsStream::setup('root');
+        $this->testDir = vfsStream::url('root');
     }
 
     #[Test]
@@ -214,9 +193,13 @@ final class FileArrayWriterTest extends TestCase
 
         $fileArrayWriter->writeArray(['id-1' => ['kind' => 'ip', 'value' => '1.1.1.1']]);
 
-        // Check no temp files remain
-        $files = glob($this->testDir . '/cleanup.json.*');
-        self::assertEmpty($files);
+        // Check no temp files remain (lock file is expected to persist)
+        $allFiles = scandir($this->testDir);
+        $tempFiles = array_filter(
+            $allFiles !== false ? $allFiles : [],
+            static fn(string $f): bool => str_starts_with($f, 'cleanup.json.') && !str_ends_with($f, '.lock'),
+        );
+        self::assertEmpty($tempFiles);
     }
 
     #[Test]
@@ -270,5 +253,91 @@ final class FileArrayWriterTest extends TestCase
 
         self::assertCount($expectedCount, $result);
         self::assertSame($data, $result);
+    }
+
+    #[Test]
+    public function readModifyWriteAppliesModification(): void
+    {
+        $filePath = $this->testDir . '/rmw.json';
+        $fileArrayWriter = new FileArrayWriter($filePath);
+        $fileArrayWriter->writeArray(['id-1' => ['kind' => 'ip', 'value' => '1.1.1.1']]);
+
+        $fileArrayWriter->readModifyWrite(function (array $data): array {
+            $data['id-2'] = ['kind' => 'cidr', 'value' => '10.0.0.0/8'];
+            return $data;
+        });
+
+        $result = $fileArrayWriter->readArray();
+        self::assertCount(2, $result);
+        self::assertArrayHasKey('id-1', $result);
+        self::assertArrayHasKey('id-2', $result);
+        self::assertSame('10.0.0.0/8', $result['id-2']['value']);
+    }
+
+    #[Test]
+    public function readModifyWriteSkipsWriteWhenModifierReturnsNull(): void
+    {
+        $filePath = $this->testDir . '/rmw_null.json';
+        $fileArrayWriter = new FileArrayWriter($filePath);
+        $original = ['id-1' => ['kind' => 'ip', 'value' => '1.1.1.1']];
+        $fileArrayWriter->writeArray($original);
+
+        // Set mtime to a known value in the past so any write would change it
+        touch($filePath, 1000);
+        clearstatcache(true, $filePath);
+
+        $fileArrayWriter->readModifyWrite(fn(array $data): ?array => null);
+
+        clearstatcache(true, $filePath);
+        self::assertSame(1000, filemtime($filePath), 'File should not have been rewritten');
+        self::assertSame($original, $fileArrayWriter->readArray());
+    }
+
+    #[Test]
+    public function readModifyWriteStartsFromEmptyArrayWhenFileMissing(): void
+    {
+        $filePath = $this->testDir . '/missing.json';
+        $fileArrayWriter = new FileArrayWriter($filePath);
+
+        $seen = null;
+        $fileArrayWriter->readModifyWrite(function (array $data) use (&$seen): array {
+            $seen = $data;
+            $data['id-1'] = ['kind' => 'ip', 'value' => '1.1.1.1'];
+            return $data;
+        });
+
+        self::assertSame([], $seen);
+        self::assertSame(['id-1' => ['kind' => 'ip', 'value' => '1.1.1.1']], $fileArrayWriter->readArray());
+    }
+
+    #[Test]
+    public function readModifyWriteReleasesLockAndPreservesFileWhenModifierThrows(): void
+    {
+        $filePath = $this->testDir . '/throws.json';
+        $fileArrayWriter = new FileArrayWriter($filePath);
+        $original = ['id-1' => ['kind' => 'ip', 'value' => '1.1.1.1']];
+        $fileArrayWriter->writeArray($original);
+        touch($filePath, 1000);
+        clearstatcache(true, $filePath);
+
+        try {
+            $fileArrayWriter->readModifyWrite(function (): array {
+                throw new \RuntimeException('boom', 1495786251);
+            });
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException) {
+            // expected
+        }
+
+        clearstatcache(true, $filePath);
+        self::assertSame(1000, filemtime($filePath), 'File should not have been rewritten');
+        self::assertSame($original, $fileArrayWriter->readArray());
+
+        // The lock must be released, so a subsequent call must succeed.
+        $fileArrayWriter->readModifyWrite(function (array $data): array {
+            $data['id-2'] = ['kind' => 'cidr', 'value' => '10.0.0.0/8'];
+            return $data;
+        });
+        self::assertArrayHasKey('id-2', $fileArrayWriter->readArray());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
 		"friendsofphp/php-cs-fixer": "3.92.0",
 		"helmich/typo3-typoscript-lint": "^3.3.0",
 		"icanhazstring/composer-unused": "0.8.11 || 0.9.3",
+		"mikey179/vfsstream": "^1.6",
 		"php-parallel-lint/php-parallel-lint": "1.4.0",
 		"phpmd/phpmd": "2.15.0",
 		"phpstan/extension-installer": "1.4.3",


### PR DESCRIPTION
The locked write used flock() for mutual exclusion but delegated the actual write to GeneralUtility::writeFile(), which adds chmod/chgrp via fixPermissions() on top. This is unnecessary overhead and incompatible with non-local stream wrappers.

Replace with file_put_contents() so the locked write path is flock + write-to-temp + rename using only plain PHP. Replace mkdir_deep() with mkdir() for the same reason.

Adapt tests to use bovigo/vfsStream accordingly.