### PR TITLE
Bump dev-main branch-alias to 0.4.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-main": "0.1.x-dev"
+			"dev-main": "0.4.x-dev"
 		},
 		"typo3/cms": {
 			"extension-key": "firewall",


### PR DESCRIPTION
The alias was stale at 0.1.x-dev while the latest release is 0.3.0. Point dev-main at 0.4.x-dev so it tracks the upcoming 0.4.0 release line and satisfies consumers requiring ^0.4.0.