### PR TITLE
Fall back to the default config when loading phirewall.php fails

### DIFF
--- a/Classes/ConfigFactory.php
+++ b/Classes/ConfigFactory.php
@@ -30,21 +30,45 @@ class ConfigFactory
     public function fromFile(string $configPath): Config
     {
         if (is_file($configPath)) {
-            $configClosure = require $configPath;
-            $config = null;
+            try {
+                $configClosure = require $configPath;
+                $config = null;
 
-            if ($configClosure instanceof \Closure) {
-                $config = $configClosure($this->eventDispatcher);
+                if ($configClosure instanceof \Closure) {
+                    $config = $configClosure($this->eventDispatcher);
+                }
+
+                if ($config instanceof Config) {
+                    return $this->prepareConfig($config);
+                }
+
+                $this->logger?->warning('Invalid phirewall.php configuration file', ['path' => $configPath]);
+            } catch (\Throwable $throwable) {
+                $this->logger?->error($this->describeConfigurationError($throwable), [
+                    'path' => $configPath,
+                    'exception' => $throwable,
+                ]);
             }
-
-            if ($config instanceof Config) {
-                return $this->prepareConfig($config);
-            }
-
-            $this->logger?->warning('Invalid phirewall.php configuration file', ['path' => $configPath]);
         }
 
         return $this->getDefaultConfig();
+    }
+
+    /**
+     * A targeted hint for the common mistake of handing the mysqli based
+     * TYPO3 connection to the PDO based store.
+     */
+    private function describeConfigurationError(\Throwable $throwable): string
+    {
+        if ($throwable instanceof \TypeError
+            && str_contains($throwable->getMessage(), 'PDO')
+            && str_contains($throwable->getMessage(), 'mysqli')
+        ) {
+            return 'Loading phirewall.php failed: the TYPO3 database connection uses the mysqli driver, '
+                . 'but PdoCache needs a PDO driver such as pdo_mysql. Using the fallback configuration.';
+        }
+
+        return 'Loading phirewall.php failed, using the fallback configuration: ' . $throwable->getMessage();
     }
 
     private function getDefaultConfig(): Config

--- a/Tests/Unit/ConfigFactoryTest.php
+++ b/Tests/Unit/ConfigFactoryTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\ListenerProviderInterface;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Core\Http\ServerRequest;
 
@@ -105,7 +107,65 @@ final class ConfigFactoryTest extends TestCase
         self::assertInstanceOf(\Closure::class, $config->getIpResolver());
     }
 
-    private function createFactory(): ConfigFactory
+    #[Test]
+    public function fromFileFallsBackAndLogsAnErrorWhenTheConfigurationThrows(): void
+    {
+        $configPath = $this->writeConfigurationFile('<?php return function () { throw new \RuntimeException(\'boom\'); };');
+        $spyLogger = $this->createSpyLogger();
+
+        $config = $this->createFactory($spyLogger)->fromFile($configPath);
+
+        self::assertInstanceOf(\Closure::class, $config->getIpResolver());
+        self::assertCount(1, $spyLogger->records);
+        self::assertSame('error', $spyLogger->records[0]['level']);
+        self::assertStringContainsString('boom', $spyLogger->records[0]['message']);
+    }
+
+    #[Test]
+    public function fromFileFallsBackAndLogsAnErrorOnASyntaxError(): void
+    {
+        $configPath = $this->writeConfigurationFile('<?php return function ( { broken');
+        $spyLogger = $this->createSpyLogger();
+
+        $config = $this->createFactory($spyLogger)->fromFile($configPath);
+
+        self::assertInstanceOf(\Closure::class, $config->getIpResolver());
+        self::assertCount(1, $spyLogger->records);
+        self::assertSame('error', $spyLogger->records[0]['level']);
+    }
+
+    #[Test]
+    public function fromFileLogsAPdoDriverHintForTheMysqliTypeError(): void
+    {
+        $configPath = $this->writeConfigurationFile(
+            '<?php return function () { throw new \TypeError(\'PdoCache::__construct(): Argument #1 ($pdo) must be of type PDO, mysqli given\'); };'
+        );
+        $spyLogger = $this->createSpyLogger();
+
+        $this->createFactory($spyLogger)->fromFile($configPath);
+
+        self::assertCount(1, $spyLogger->records);
+        self::assertStringContainsString('pdo_mysql', $spyLogger->records[0]['message']);
+        self::assertStringContainsString('mysqli driver', $spyLogger->records[0]['message']);
+    }
+
+    /**
+     * @return AbstractLogger&object{records: list<array{level: string, message: string}>}
+     */
+    private function createSpyLogger(): AbstractLogger
+    {
+        return new class () extends AbstractLogger {
+            /** @var list<array{level: string, message: string}> */
+            public array $records = [];
+
+            public function log($level, \Stringable|string $message, array $context = []): void
+            {
+                $this->records[] = ['level' => is_string($level) ? $level : 'unknown', 'message' => (string)$message];
+            }
+        };
+    }
+
+    private function createFactory(?LoggerInterface $logger = null): ConfigFactory
     {
         $listenerProvider = new class () implements ListenerProviderInterface {
             /**
@@ -117,7 +177,7 @@ final class ConfigFactoryTest extends TestCase
             }
         };
 
-        return new ConfigFactory(new EventDispatcher($listenerProvider));
+        return new ConfigFactory(new EventDispatcher($listenerProvider), $logger);
     }
 
     private function writeConfigurationFile(string $content): string


### PR DESCRIPTION
A failing configuration file logged nothing and broke every request. The error is now logged and the site keeps running on the fallback configuration, with a targeted hint when the mysqli connection is handed to the PDO based store.