### PR TITLE
Layer the configuration file over the extension defaults

### DIFF
--- a/Classes/ConfigFactory.php
+++ b/Classes/ConfigFactory.php
@@ -9,6 +9,7 @@ use Flowd\Phirewall\Store\InMemoryCache;
 use Flowd\Typo3Firewall\Pattern\FileArrayPatternBackend;
 use Flowd\Typo3Firewall\Writer\FileArrayWriter;
 use Psr\Log\LoggerInterface;
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
@@ -39,7 +40,9 @@ class ConfigFactory
                 }
 
                 if ($config instanceof Config) {
-                    return $this->prepareConfig($config);
+                    // The extension defaults form the base layer; the configuration
+                    // file is merged on top and wins on every name clash.
+                    return $this->createBaseConfig($config->cache)->with($config);
                 }
 
                 $this->logger?->warning('Invalid phirewall.php configuration file', ['path' => $configPath]);
@@ -73,34 +76,28 @@ class ConfigFactory
 
     private function getDefaultConfig(): Config
     {
-        return $this->prepareConfig(new Config(new InMemoryCache(), $this->eventDispatcher));
+        return $this->createBaseConfig(new InMemoryCache());
     }
 
-    private function prepareConfig(Config $config): Config
+    /**
+     * The defaults every installation gets: the TYPO3 client IP resolver and
+     * the blocklist fed from the backend managed patterns. The configuration
+     * file is layered on top, so it can override both by name.
+     */
+    private function createBaseConfig(CacheInterface $cache): Config
     {
-        $this->applyDefaultIpResolver($config);
-        return $this->addTypo3ManagedPatternsBlocklist($config);
-    }
-
-    private function applyDefaultIpResolver(Config $config): void
-    {
-        if ($config->getIpResolver() instanceof \Closure) {
-            return;
-        }
+        $config = new Config($cache, $this->eventDispatcher);
 
         // getIndpEnv() applies TYPO3's reverseProxyIP settings, so rules key on the real client IP.
         $config->setIpResolver(static function (): ?string {
             $remoteAddress = GeneralUtility::getIndpEnv('REMOTE_ADDR');
             return is_string($remoteAddress) && $remoteAddress !== '' ? $remoteAddress : null;
         });
-    }
 
-    private function addTypo3ManagedPatternsBlocklist(Config $config): Config
-    {
         $patternPath = self::getPatternsFilePath();
         $fileArrayPatternBackend = new FileArrayPatternBackend($patternPath, new FileArrayWriter($patternPath, $this->logger), $this->logger);
-
         $config->blocklists->addPatternBackend('typo3-managed-patterns', $fileArrayPatternBackend)->fromBackend('typo3-blocklist', 'typo3-managed-patterns');
+
         return $config;
     }
 

--- a/Tests/Unit/ConfigFactoryTest.php
+++ b/Tests/Unit/ConfigFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flowd\Typo3Firewall\Tests\Unit;
 
+use Flowd\Phirewall\Store\PdoCache;
 use Flowd\Typo3Firewall\ConfigFactory;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -95,6 +96,61 @@ final class ConfigFactoryTest extends TestCase
 
         self::assertInstanceOf(\Closure::class, $ipResolver);
         self::assertSame('198.51.100.9', $ipResolver(new ServerRequest()));
+    }
+
+    #[Test]
+    public function fromFileKeepsTheCacheOfTheConfigurationFile(): void
+    {
+        $configPath = $this->writeConfigurationFile(<<<'PHP'
+            <?php
+            use Flowd\Phirewall\Config;
+            use Flowd\Phirewall\Store\PdoCache;
+            use Psr\EventDispatcher\EventDispatcherInterface;
+
+            return function (EventDispatcherInterface $eventDispatcher): Config {
+                return new Config(new PdoCache(new \PDO('sqlite::memory:')), $eventDispatcher);
+            };
+            PHP);
+
+        $config = $this->createFactory()->fromFile($configPath);
+
+        self::assertInstanceOf(PdoCache::class, $config->cache);
+    }
+
+    #[Test]
+    public function fromFileAddsTheBackendPatternsBlocklistFirst(): void
+    {
+        $configPath = $this->writeConfigurationFile(self::CONFIG_WITHOUT_IP_RESOLVER);
+
+        $config = $this->createFactory()->fromFile($configPath);
+
+        self::assertSame('typo3-blocklist', array_key_first($config->blocklists->rules()));
+    }
+
+    #[Test]
+    public function fromFileLetsTheConfigurationOverrideTheBackendPatternsBlocklist(): void
+    {
+        $configPath = $this->writeConfigurationFile(<<<'PHP'
+            <?php
+            use Flowd\Phirewall\Config;
+            use Flowd\Phirewall\Store\InMemoryCache;
+            use Psr\EventDispatcher\EventDispatcherInterface;
+
+            return function (EventDispatcherInterface $eventDispatcher): Config {
+                $config = new Config(new InMemoryCache(), $eventDispatcher);
+                $config->blocklists->add(
+                    name: 'typo3-blocklist',
+                    callback: fn($request): bool => $request->getUri()->getPath() === '/overridden'
+                );
+                return $config;
+            };
+            PHP);
+
+        $config = $this->createFactory()->fromFile($configPath);
+        $rules = $config->blocklists->rules();
+
+        self::assertArrayHasKey('typo3-blocklist', $rules);
+        self::assertTrue($rules['typo3-blocklist']->matcher()->match(new ServerRequest('https://example.com/overridden'))->isMatch());
     }
 
     #[Test]


### PR DESCRIPTION
The extension defaults (IP resolver, typo3-blocklist) form the base config on the cache of the configuration file; the file is merged on top via Config::with(), so it wins on every name clash and can now override the typo3-blocklist rule.