### PR TITLE
Warn when counter rules run on the InMemoryCache store

### DIFF
--- a/Classes/Backend/Controller/FirewallController.php
+++ b/Classes/Backend/Controller/FirewallController.php
@@ -8,6 +8,7 @@ use Flowd\Phirewall\BanType;
 use Flowd\Phirewall\Config;
 use Flowd\Phirewall\Pattern\PatternEntry;
 use Flowd\Phirewall\Pattern\PatternKind;
+use Flowd\Phirewall\Store\InMemoryCache;
 use Flowd\Typo3Firewall\ConfigFactory;
 use Flowd\Typo3Firewall\Dto\PatternEntryDto;
 use Flowd\Typo3Firewall\Pattern\FileArrayPatternBackend;
@@ -149,6 +150,7 @@ class FirewallController extends ActionController
             'banGroups' => $banGroups,
             'totalBans' => $totalBans,
             'search' => $search,
+            'usesInMemoryStore' => $this->config->cache instanceof InMemoryCache,
         ]);
 
         return $moduleTemplate->renderResponse('Backend/Firewall/Bans');

--- a/Classes/ConfigFactory.php
+++ b/Classes/ConfigFactory.php
@@ -42,7 +42,7 @@ class ConfigFactory
                 if ($config instanceof Config) {
                     // The extension defaults form the base layer; the configuration
                     // file is merged on top and wins on every name clash.
-                    return $this->createBaseConfig($config->cache)->with($config);
+                    return $this->warnAboutNonPersistentStore($this->createBaseConfig($config->cache)->with($config));
                 }
 
                 $this->logger?->warning('Invalid phirewall.php configuration file', ['path' => $configPath]);
@@ -72,6 +72,35 @@ class ConfigFactory
         }
 
         return 'Loading phirewall.php failed, using the fallback configuration: ' . $throwable->getMessage();
+    }
+
+    /**
+     * Throttle and ban counters need a store that persists between requests.
+     * With InMemoryCache every HTTP request starts at zero, so such rules
+     * silently never trigger; make that failure loud.
+     */
+    private function warnAboutNonPersistentStore(Config $config): Config
+    {
+        if ($this->isCliRequest() || !$config->cache instanceof InMemoryCache) {
+            return $config;
+        }
+
+        if ($config->throttles->rules() === [] && $config->fail2ban->rules() === [] && $config->allow2ban->rules() === []) {
+            return $config;
+        }
+
+        $this->logger?->warning(
+            'Throttle, fail2ban, or allow2ban rules are registered on the InMemoryCache store. '
+            . 'Counters do not persist between requests under PHP-FPM, so these rules never trigger. '
+            . 'Use ApcuCache or RedisCache instead, see the Storage chapter of the manual.'
+        );
+
+        return $config;
+    }
+
+    protected function isCliRequest(): bool
+    {
+        return PHP_SAPI === 'cli';
     }
 
     private function getDefaultConfig(): Config

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -428,6 +428,9 @@
       <trans-unit id="widgets.events.dataset">
         <source>Blocked requests</source>
       </trans-unit>
+      <trans-unit id="bans.storeWarning">
+        <source>The firewall uses the InMemoryCache store. Counters and bans do not persist between requests, so rate limiting and bans do not work and this view stays empty. Configure a persistent store such as ApcuCache or RedisCache.</source>
+      </trans-unit>
       <trans-unit id="bans.field.expiresIn">
         <source>Expires in</source>
       </trans-unit>

--- a/Resources/Private/Templates/Backend/Firewall/Bans.html
+++ b/Resources/Private/Templates/Backend/Firewall/Bans.html
@@ -6,6 +6,13 @@
 <f:section name="Content">
     <f:flashMessages />
 
+    <f:if condition="{usesInMemoryStore}">
+        <div class="alert alert-warning">
+            <core:icon identifier="actions-exclamation" size="small" />
+            <f:translate key="bans.storeWarning" />
+        </div>
+    </f:if>
+
     <div class="card mb-4">
         <div class="card-header d-flex justify-content-between align-items-center">
             <span>

--- a/Tests/Functional/Backend/Controller/FirewallControllerTest.php
+++ b/Tests/Functional/Backend/Controller/FirewallControllerTest.php
@@ -213,6 +213,16 @@ final class FirewallControllerTest extends FunctionalTestCase
     }
 
     #[Test]
+    public function bansActionWarnsAboutTheInMemoryStore(): void
+    {
+        $this->setUpConfigWithFail2BanRule();
+
+        $response = $this->dispatchModuleRequest('bans');
+
+        self::assertStringContainsString('InMemoryCache', (string)$response->getBody());
+    }
+
+    #[Test]
     public function bansActionShowsTheRemainingBanTime(): void
     {
         $config = $this->setUpConfigWithFail2BanRule();

--- a/Tests/Unit/ConfigFactoryTest.php
+++ b/Tests/Unit/ConfigFactoryTest.php
@@ -205,6 +205,55 @@ final class ConfigFactoryTest extends TestCase
         self::assertStringContainsString('mysqli driver', $spyLogger->records[0]['message']);
     }
 
+    #[Test]
+    public function fromFileWarnsWhenThrottleRulesRunOnTheInMemoryStore(): void
+    {
+        $configPath = $this->writeConfigurationFile(<<<'PHP'
+            <?php
+            use Flowd\Phirewall\Config;
+            use Flowd\Phirewall\Store\InMemoryCache;
+            use Psr\EventDispatcher\EventDispatcherInterface;
+
+            return function (EventDispatcherInterface $eventDispatcher): Config {
+                $config = new Config(new InMemoryCache(), $eventDispatcher);
+                $config->throttles->add(name: 'api-throttle', limit: 10, period: 60);
+                return $config;
+            };
+            PHP);
+        $spyLogger = $this->createSpyLogger();
+
+        $this->createFactory($spyLogger, cli: false)->fromFile($configPath);
+
+        self::assertCount(1, $spyLogger->records);
+        self::assertSame('warning', $spyLogger->records[0]['level']);
+        self::assertStringContainsString('InMemoryCache', $spyLogger->records[0]['message']);
+    }
+
+    #[Test]
+    public function fromFileDoesNotWarnOnCliOrWithoutCounterRules(): void
+    {
+        $throttleConfig = <<<'PHP'
+            <?php
+            use Flowd\Phirewall\Config;
+            use Flowd\Phirewall\Store\InMemoryCache;
+            use Psr\EventDispatcher\EventDispatcherInterface;
+
+            return function (EventDispatcherInterface $eventDispatcher): Config {
+                $config = new Config(new InMemoryCache(), $eventDispatcher);
+                $config->throttles->add(name: 'api-throttle', limit: 10, period: 60);
+                return $config;
+            };
+            PHP;
+
+        $cliLogger = $this->createSpyLogger();
+        $this->createFactory($cliLogger, cli: true)->fromFile($this->writeConfigurationFile($throttleConfig));
+        self::assertSame([], $cliLogger->records);
+
+        $blocklistOnlyLogger = $this->createSpyLogger();
+        $this->createFactory($blocklistOnlyLogger, cli: false)->fromFile($this->writeConfigurationFile(self::CONFIG_WITHOUT_IP_RESOLVER));
+        self::assertSame([], $blocklistOnlyLogger->records);
+    }
+
     /**
      * @return AbstractLogger&object{records: list<array{level: string, message: string}>}
      */
@@ -221,7 +270,7 @@ final class ConfigFactoryTest extends TestCase
         };
     }
 
-    private function createFactory(?LoggerInterface $logger = null): ConfigFactory
+    private function createFactory(?LoggerInterface $logger = null, bool $cli = true): ConfigFactory
     {
         $listenerProvider = new class () implements ListenerProviderInterface {
             /**
@@ -233,7 +282,17 @@ final class ConfigFactoryTest extends TestCase
             }
         };
 
-        return new ConfigFactory(new EventDispatcher($listenerProvider), $logger);
+        return new class (new EventDispatcher($listenerProvider), $logger, $cli) extends ConfigFactory {
+            public function __construct(EventDispatcher $eventDispatcher, ?LoggerInterface $logger, private readonly bool $cli)
+            {
+                parent::__construct($eventDispatcher, $logger);
+            }
+
+            protected function isCliRequest(): bool
+            {
+                return $this->cli;
+            }
+        };
     }
 
     private function writeConfigurationFile(string $content): string


### PR DESCRIPTION
Throttle, fail2ban, and allow2ban counters never persist between requests with InMemoryCache, so such rules silently do nothing under PHP-FPM. The factory now logs a warning for that combination outside of CLI, and the blocked keys view shows a matching notice.

References #26 