### PR TITLE
Expose the firewall decision as a TYPO3 Context aspect

### DIFF
--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -1,4 +1,5 @@
 includes:
+  - ../../phpstan-extension.neon
   - ../../.Build/vendor/spaze/phpstan-disallowed-calls/disallowed-dangerous-calls.neon
   - ../../.Build/vendor/spaze/phpstan-disallowed-calls/disallowed-execution-calls.neon
   - ../../.Build/vendor/spaze/phpstan-disallowed-calls/disallowed-insecure-calls.neon

--- a/Classes/Context/FirewallAspect.php
+++ b/Classes/Context/FirewallAspect.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowd\Typo3Firewall\Context;
+
+use Flowd\Phirewall\Context\RequestContext;
+use Flowd\Phirewall\Http\FirewallResult;
+use TYPO3\CMS\Core\Context\AspectInterface;
+use TYPO3\CMS\Core\Context\Exception\AspectPropertyNotFoundException;
+
+/**
+ * Exposes the firewall decision of the current request through the TYPO3
+ * Context API. Registered by the RegisterFirewallAspectMiddleware.
+ */
+final readonly class FirewallAspect implements AspectInterface
+{
+    public function __construct(private RequestContext $requestContext) {}
+
+    public function get(string $name): RequestContext|FirewallResult
+    {
+        return match ($name) {
+            'context' => $this->requestContext,
+            'result' => $this->requestContext->getResult(),
+            default => throw new AspectPropertyNotFoundException(
+                sprintf('Property "%s" not found in firewall aspect.', $name),
+                1780065304
+            ),
+        };
+    }
+
+    /**
+     * Report an application-level failure (e.g. a failed login) to a fail2ban
+     * rule. Without a key the firewall derives the discriminator from the
+     * rule's key extractor, falling back to the resolved client IP.
+     */
+    public function recordFailure(string $ruleName, ?string $key = null): void
+    {
+        $this->requestContext->recordFailure($ruleName, $key);
+    }
+
+    /**
+     * Report a hit to an allow2ban rule, e.g. an expensive operation the
+     * pre-handler path cannot see. Key resolution as in recordFailure().
+     */
+    public function recordHit(string $ruleName, ?string $key = null): void
+    {
+        $this->requestContext->recordHit($ruleName, $key);
+    }
+}

--- a/Classes/Middleware/RegisterFirewallAspectMiddleware.php
+++ b/Classes/Middleware/RegisterFirewallAspectMiddleware.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowd\Typo3Firewall\Middleware;
+
+use Flowd\Phirewall\Context\RequestContext;
+use Flowd\Typo3Firewall\Context\FirewallAspect;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Context\Context;
+
+/**
+ * Registers the "firewall" Context aspect, see the Middleware chapter of
+ * the manual.
+ */
+final readonly class RegisterFirewallAspectMiddleware implements MiddlewareInterface
+{
+    public function __construct(private Context $context) {}
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $requestContext = $request->getAttribute(RequestContext::ATTRIBUTE_NAME);
+
+        // Without the firewall middleware there is no decision to expose.
+        if ($requestContext instanceof RequestContext) {
+            $this->context->setAspect('firewall', new FirewallAspect($requestContext));
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Flowd\Phirewall\Middleware;
+use Flowd\Typo3Firewall\Middleware\RegisterFirewallAspectMiddleware;
 
 return [
     'frontend' => [
@@ -10,6 +11,15 @@ return [
             'target' => Middleware::class,
             'after' => [
                 'typo3/cms-frontend/timetracker',
+            ],
+            'before' => [
+                'typo3/cms-core/normalized-params-attribute',
+            ],
+        ],
+        'flowd/typo3-firewall-aspect' => [
+            'target' => RegisterFirewallAspectMiddleware::class,
+            'after' => [
+                'flowd/typo3-firewall',
             ],
             'before' => [
                 'typo3/cms-core/normalized-params-attribute',

--- a/Documentation/Middleware.rst
+++ b/Documentation/Middleware.rst
@@ -51,3 +51,62 @@ Return a configuration without rules, or rename the configuration file. The
 extension then falls back to the default configuration, and only the block
 patterns from the :doc:`backend module <BackendModule>` stay active. To
 disable those too, remove the patterns in the backend module.
+
+Read the firewall decision from PHP code
+========================================
+
+A second middleware ``flowd/typo3-firewall-aspect`` exposes the firewall
+decision through the TYPO3 Context API as the ``firewall`` aspect. Like the
+firewall itself it runs in the frontend stack only, so the aspect is
+available in frontend requests and not in the backend. Application code can
+read the decision through the aspect:
+
+..  code-block:: php
+
+    use TYPO3\CMS\Core\Context\Context;
+    use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+    $firewallAspect = GeneralUtility::makeInstance(Context::class)->getAspect('firewall');
+
+    // The FirewallResult of the current request:
+    $firewallResult = $firewallAspect->get('result');
+
+    // Report an application-level failure, for example a failed login,
+    // to a fail2ban rule defined in phirewall.php:
+    $firewallAspect->recordFailure('login-failures');
+
+    // Report a hit to an allow2ban rule, for example an expensive
+    // operation the firewall cannot see from the request alone:
+    $firewallAspect->recordHit('expensive-operation');
+
+``recordFailure()`` and ``recordHit()`` count against the client IP by
+default; the firewall resolves it with your trusted-proxy settings after
+the handler has finished. Pass a key as second argument only when the rule
+should count something the firewall cannot derive from the request itself.
+Signals reported to a rule name that is not configured are ignored, so
+calling code does not need to check the configuration first.
+
+The extension ships a `phpstan <https://phpstan.org/>`__ configuration that
+maps ``getAspect('firewall')`` to the :php:`FirewallAspect` class. Projects
+using ``phpstan/extension-installer`` pick it up automatically.
+
+..  note::
+
+    The aspect is only registered when the firewall middleware has run for
+    the current request. Otherwise ``getAspect('firewall')`` throws an
+    ``AspectNotFoundException``.
+
+If you do not want the aspect registered at all, disable the middleware in
+the :file:`Configuration/RequestMiddlewares.php` of your site package:
+
+..  code-block:: php
+
+    <?php
+
+    return [
+        'frontend' => [
+            'flowd/typo3-firewall-aspect' => [
+                'disabled' => true,
+            ],
+        ],
+    ];

--- a/Tests/Unit/Context/FirewallAspectTest.php
+++ b/Tests/Unit/Context/FirewallAspectTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowd\Typo3Firewall\Tests\Unit\Context;
+
+use Flowd\Phirewall\BanType;
+use Flowd\Phirewall\Context\RequestContext;
+use Flowd\Phirewall\Http\FirewallResult;
+use Flowd\Typo3Firewall\Context\FirewallAspect;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Context\Exception\AspectPropertyNotFoundException;
+
+#[CoversClass(FirewallAspect::class)]
+final class FirewallAspectTest extends TestCase
+{
+    #[Test]
+    public function getContextReturnsTheWrappedRequestContext(): void
+    {
+        $requestContext = new RequestContext(FirewallResult::pass());
+        $firewallAspect = new FirewallAspect($requestContext);
+
+        self::assertSame($requestContext, $firewallAspect->get('context'));
+    }
+
+    #[Test]
+    public function getResultReturnsTheRequestContextResult(): void
+    {
+        $firewallResult = FirewallResult::blocked('sqli', 'owasp');
+        $firewallAspect = new FirewallAspect(new RequestContext($firewallResult));
+
+        self::assertSame($firewallResult, $firewallAspect->get('result'));
+    }
+
+    #[Test]
+    public function getUnknownPropertyThrows(): void
+    {
+        $firewallAspect = new FirewallAspect(new RequestContext(FirewallResult::pass()));
+
+        $this->expectException(AspectPropertyNotFoundException::class);
+        $this->expectExceptionCode(1780065304);
+
+        $firewallAspect->get('does-not-exist');
+    }
+
+    #[Test]
+    public function recordFailureDelegatesToTheRequestContext(): void
+    {
+        $requestContext = new RequestContext(FirewallResult::pass());
+        $firewallAspect = new FirewallAspect($requestContext);
+
+        $firewallAspect->recordFailure('form-flood', '10.0.0.7');
+
+        self::assertTrue($requestContext->hasRecordedSignals());
+        $recordedSignals = $requestContext->getRecordedSignals();
+        self::assertCount(1, $recordedSignals);
+        self::assertSame('form-flood', $recordedSignals[0]->ruleName);
+        self::assertSame(BanType::Fail2Ban, $recordedSignals[0]->banType);
+        self::assertSame('10.0.0.7', $recordedSignals[0]->key);
+    }
+
+    #[Test]
+    public function recordFailureWithoutKeyLeavesTheKeyResolutionToTheFirewall(): void
+    {
+        $requestContext = new RequestContext(FirewallResult::pass());
+        $firewallAspect = new FirewallAspect($requestContext);
+
+        $firewallAspect->recordFailure('login-failures');
+
+        self::assertNull($requestContext->getRecordedSignals()[0]->key);
+    }
+
+    #[Test]
+    public function recordHitDelegatesToTheRequestContext(): void
+    {
+        $requestContext = new RequestContext(FirewallResult::pass());
+        $firewallAspect = new FirewallAspect($requestContext);
+
+        $firewallAspect->recordHit('expensive-operation', '10.0.0.7');
+
+        $recordedSignals = $requestContext->getRecordedSignals();
+        self::assertCount(1, $recordedSignals);
+        self::assertSame('expensive-operation', $recordedSignals[0]->ruleName);
+        self::assertSame(BanType::Allow2Ban, $recordedSignals[0]->banType);
+        self::assertSame('10.0.0.7', $recordedSignals[0]->key);
+    }
+
+    #[Test]
+    public function recordHitWithoutKeyLeavesTheKeyResolutionToTheFirewall(): void
+    {
+        $requestContext = new RequestContext(FirewallResult::pass());
+        $firewallAspect = new FirewallAspect($requestContext);
+
+        $firewallAspect->recordHit('expensive-operation');
+
+        self::assertNull($requestContext->getRecordedSignals()[0]->key);
+    }
+}

--- a/Tests/Unit/Middleware/RegisterFirewallAspectMiddlewareTest.php
+++ b/Tests/Unit/Middleware/RegisterFirewallAspectMiddlewareTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowd\Typo3Firewall\Tests\Unit\Middleware;
+
+use Flowd\Phirewall\Context\RequestContext;
+use Flowd\Phirewall\Http\FirewallResult;
+use Flowd\Typo3Firewall\Context\FirewallAspect;
+use Flowd\Typo3Firewall\Middleware\RegisterFirewallAspectMiddleware;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Http\Response;
+use TYPO3\CMS\Core\Http\ServerRequest;
+
+#[CoversClass(RegisterFirewallAspectMiddleware::class)]
+final class RegisterFirewallAspectMiddlewareTest extends TestCase
+{
+    #[Test]
+    public function processRegistersTheFirewallAspect(): void
+    {
+        $requestContext = new RequestContext(FirewallResult::pass());
+        $serverRequest = (new ServerRequest('https://example.com/'))
+            ->withAttribute(RequestContext::ATTRIBUTE_NAME, $requestContext);
+        $context = new Context();
+
+        $response = (new RegisterFirewallAspectMiddleware($context))->process($serverRequest, $this->handler());
+
+        $firewallAspect = $context->getAspect('firewall');
+        self::assertInstanceOf(FirewallAspect::class, $firewallAspect);
+        self::assertSame($requestContext, $firewallAspect->get('context'));
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function processSkipsTheAspectWhenTheFirewallMiddlewareDidNotRun(): void
+    {
+        $context = new Context();
+
+        $response = (new RegisterFirewallAspectMiddleware($context))
+            ->process(new ServerRequest('https://example.com/'), $this->handler());
+
+        self::assertFalse($context->hasAspect('firewall'));
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    private function handler(): RequestHandlerInterface
+    {
+        return new class () implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new Response();
+            }
+        };
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,11 @@
 		"branch-alias": {
 			"dev-main": "0.4.x-dev"
 		},
+		"phpstan": {
+			"includes": [
+				"phpstan-extension.neon"
+			]
+		},
 		"typo3/cms": {
 			"extension-key": "firewall",
 			"web-dir": ".Build/public"

--- a/phpstan-extension.neon
+++ b/phpstan-extension.neon
@@ -1,0 +1,4 @@
+parameters:
+    typo3:
+        contextApiGetAspectMapping:
+            firewall: Flowd\Typo3Firewall\Context\FirewallAspect


### PR DESCRIPTION
FirewallAspect plus RegisterFirewallAspectMiddleware let application code read the firewall decision and record fail2ban/allow2ban signals through the Context API. Ships a phpstan mapping so getAspect('firewall') is typed for consumers.