### PR TITLE
Require phirewall 0.8 and log fail2ban matches

### DIFF
--- a/Classes/EventLog/FirewallEventLogListener.php
+++ b/Classes/EventLog/FirewallEventLogListener.php
@@ -8,6 +8,7 @@ use Flowd\Phirewall\BanType;
 use Flowd\Phirewall\Events\Allow2BanBanned;
 use Flowd\Phirewall\Events\BlocklistMatched;
 use Flowd\Phirewall\Events\Fail2BanBanned;
+use Flowd\Phirewall\Events\Fail2BanMatched;
 use Flowd\Phirewall\Events\FirewallError;
 use Flowd\Phirewall\Events\SafelistMatched;
 use Flowd\Phirewall\Events\ThrottleExceeded;
@@ -40,6 +41,15 @@ final class FirewallEventLogListener
             'period' => $throttleExceeded->period,
             'count' => $throttleExceeded->count,
             'retryAfter' => $throttleExceeded->retryAfter,
+        ]);
+    }
+
+    public function onFail2BanMatched(Fail2BanMatched $fail2BanMatched): void
+    {
+        $this->eventLogger->log(FirewallEventType::Fail2BanMatched, $fail2BanMatched->serverRequest, rule: $fail2BanMatched->rule, key: $fail2BanMatched->key, meta: [
+            'threshold' => $fail2BanMatched->threshold,
+            'period' => $fail2BanMatched->period,
+            'count' => $fail2BanMatched->count,
         ]);
     }
 

--- a/Classes/EventLog/FirewallEventType.php
+++ b/Classes/EventLog/FirewallEventType.php
@@ -10,6 +10,8 @@ enum FirewallEventType: string
 
     case ThrottleExceeded = 'throttle_exceeded';
 
+    case Fail2BanMatched = 'fail2ban_matched';
+
     case Fail2BanBanned = 'fail2ban_banned';
 
     case Allow2BanBanned = 'allow2ban_banned';
@@ -27,6 +29,6 @@ enum FirewallEventType: string
      */
     public static function blockingTypes(): array
     {
-        return [self::BlocklistMatched, self::ThrottleExceeded, self::Fail2BanBanned, self::Allow2BanBanned];
+        return [self::BlocklistMatched, self::ThrottleExceeded, self::Fail2BanMatched, self::Fail2BanBanned, self::Allow2BanBanned];
     }
 }

--- a/Classes/Statistics/BarChartBuilder.php
+++ b/Classes/Statistics/BarChartBuilder.php
@@ -43,6 +43,7 @@ final class BarChartBuilder
     private const array TYPE_COLORS = [
         FirewallEventType::BlocklistMatched->value => '#2a78d6',
         FirewallEventType::ThrottleExceeded->value => '#1baf7a',
+        FirewallEventType::Fail2BanMatched->value => '#d55e00',
         FirewallEventType::Fail2BanBanned->value => '#eda100',
         FirewallEventType::Allow2BanBanned->value => '#008300',
     ];

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -35,6 +35,9 @@ services:
               identifier: 'firewall-event-log/throttle-exceeded'
               method: 'onThrottleExceeded'
             - name: event.listener
+              identifier: 'firewall-event-log/fail2ban-matched'
+              method: 'onFail2BanMatched'
+            - name: event.listener
               identifier: 'firewall-event-log/fail2ban-banned'
               method: 'onFail2BanBanned'
             - name: event.listener

--- a/Documentation/Examples.rst
+++ b/Documentation/Examples.rst
@@ -39,13 +39,15 @@ ends the check at once, so these clients are never rate limited or banned.
         return $config;
     };
 
-Ban brute-force logins with fail2ban
-====================================
+Ban brute-force logins with allow2ban
+=====================================
 
-Ban a client that posts to the frontend login again and again. A fail2ban
-rule counts the requests that match its filter and bans the client once the
-threshold is reached. Replace ``/login`` with the path of the page that holds
-your felogin form.
+Ban a client that posts to the frontend login again and again. An allow2ban
+rule with a filter counts the requests that match the filter and lets them
+through, then bans the client once it crosses the threshold within the period.
+A fail2ban rule is the wrong tool here: it treats every match as malicious and
+answers each login post with a 403, which locks out real users. Replace
+``/login`` with the path of the page that holds your felogin form.
 
 ..  code-block:: php
 
@@ -58,11 +60,11 @@ your felogin form.
         $cache = new ApcuCache();
         $config = new Config($cache, $eventDispatcher);
 
-        $config->fail2ban->add(
+        $config->allow2ban->add(
             name: 'felogin-brute-force',
             threshold: 5,
             period: 300,
-            ban: 900,
+            banSeconds: 900,
             filter: fn($request) => $request->getMethod() === 'POST'
                 && str_starts_with($request->getUri()->getPath(), '/login'),
         );

--- a/Documentation/Installation.rst
+++ b/Documentation/Installation.rst
@@ -11,7 +11,7 @@ Requirements
 Extension version    0.4
 TYPO3                12.4 LTS, 13.4 LTS, 14
 PHP                  8.3, 8.4, 8.5
-Firewall engine      flowd/phirewall 0.7
+Firewall engine      flowd/phirewall 0.8
 ===================  ===============================
 
 The firewall works with every database supported by TYPO3. Rate limiting and
@@ -66,7 +66,7 @@ available without further setup.
 Upgrade from 0.3
 ================
 
-Version 0.4 updates the firewall engine from phirewall 0.3 to 0.7. Review
+Version 0.4 updates the firewall engine from phirewall 0.3 to 0.8. Review
 these points when upgrading:
 
 New database table
@@ -84,6 +84,23 @@ Bans trigger at the threshold
     one request later. With ``threshold: 5`` the ban starts at the fifth
     matching request. Lower your thresholds by one if you relied on the old
     behavior.
+
+Fail2Ban blocks every matching request
+    A fail2ban rule answers **every** request its filter matches with a
+    ``403``, not only the request that reaches the threshold; the threshold
+    controls when the client is banned outright. If a rule in your
+    ``phirewall.php`` filters on something a legitimate request can carry
+    (for example every POST to a login path), move it to an allow2ban rule
+    with the same filter, which counts the matches but lets them pass until
+    the threshold. Rules that match only clearly malicious traffic (scanner
+    paths) block the probe on sight. Rules driven by
+    ``RequestContext::recordFailure()`` (an empty filter) are unaffected.
+
+New event type ``fail2ban_matched``
+    A blocked-but-not-yet-banned fail2ban match is recorded as the new event
+    type ``fail2ban_matched`` and counts towards the blocking statistics. It
+    is enabled by default; adjust the logged types in the extension
+    configuration if you do not want it.
 
 ``$config->blocklists->owasp()`` was removed
     The OWASP rule engine moved into the package

--- a/Documentation/Presets.rst
+++ b/Documentation/Presets.rst
@@ -28,8 +28,9 @@ based on the `OWASP Core Rule Set <https://coreruleset.org/>`__:
     $config = $config->with(OwaspPresets::blocklist(ParanoiaLevel::Level1));
 
 Start with paranoia level 1. Higher levels detect more, but also produce
-more false positives. Instead of blocking directly, you can ban repeat
-offenders with the fail2ban variant:
+more false positives. The fail2ban variant blocks each matching request just
+like the blocklist, but additionally bans a client key that keeps matching,
+so a repeat offender is locked out for the whole ban period:
 
 ..  code-block:: php
 

--- a/Documentation/Statistics.rst
+++ b/Documentation/Statistics.rst
@@ -26,6 +26,10 @@ types are:
 ``throttle_exceeded``
     A client sent more requests than a rate limit allows.
 
+``fail2ban_matched``
+    A fail2ban rule blocked a request that matched its filter, before the
+    ban threshold was reached.
+
 ``fail2ban_banned``
     A fail2ban rule banned a client after repeated abuse.
 
@@ -42,8 +46,12 @@ types are:
     The firewall hit an internal error, for example when the store was
     unreachable.
 
-The first four types count as a blocked attacker. They feed the numbers, the
-chart, and the top lists in the statistics view. The ``safelist_matched`` and
+The ``blocklist_matched``, ``throttle_exceeded``, ``fail2ban_matched``,
+``fail2ban_banned``, and ``allow2ban_banned`` types count as a blocked
+attacker: each one rejected a request. They feed the numbers, the chart, and
+the top lists in the statistics view. The ``firewall_error`` type is recorded
+but not counted, because an internal error makes the firewall fail open by
+default, so the request was not blocked. The ``safelist_matched`` and
 ``track_hit`` types are high volume and switched off by default, because they
 fire on normal traffic and would fill the table quickly.
 
@@ -58,7 +66,7 @@ it under **Admin Tools** > **Settings** >
     Turns the event log on or off. When off, nothing is recorded and the
     statistics view stays empty.
 
-``eventLogTypes`` (default: ``blocklist_matched``, ``throttle_exceeded``, ``fail2ban_banned``, ``allow2ban_banned``, ``firewall_error``)
+``eventLogTypes`` (default: ``blocklist_matched``, ``throttle_exceeded``, ``fail2ban_matched``, ``fail2ban_banned``, ``allow2ban_banned``, ``firewall_error``)
     A comma-separated list of the event types to record. Add
     ``safelist_matched`` or ``track_hit`` only when you need them, and expect
     many more rows.

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -395,6 +395,9 @@
       <trans-unit id="statistics.type.throttle_exceeded">
         <source>Rate limit exceeded</source>
       </trans-unit>
+      <trans-unit id="statistics.type.fail2ban_matched">
+        <source>Fail2Ban matches</source>
+      </trans-unit>
       <trans-unit id="statistics.type.fail2ban_banned">
         <source>Fail2Ban bans</source>
       </trans-unit>

--- a/Tests/Functional/EventLog/EventLogTest.php
+++ b/Tests/Functional/EventLog/EventLogTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flowd\Typo3Firewall\Tests\Functional\EventLog;
 
 use Flowd\Phirewall\Events\BlocklistMatched;
+use Flowd\Phirewall\Events\Fail2BanMatched;
 use Flowd\Phirewall\Events\FirewallError;
 use Flowd\Phirewall\Events\SafelistMatched;
 use Flowd\Phirewall\Events\ThrottleExceeded;
@@ -74,6 +75,25 @@ final class EventLogTest extends FunctionalTestCase
         self::assertSame(hash('sha256', 'secret-api-key'), $rows[0]['key_hash']);
         self::assertSame('', $rows[0]['key_display']);
         self::assertStringNotContainsString('secret-api-key', json_encode($rows[0], JSON_THROW_ON_ERROR));
+    }
+
+    #[Test]
+    public function fail2BanMatchedEventStoresTheCounterMetaWithoutABanType(): void
+    {
+        $serverRequest = new ServerRequest('https://example.com/login', 'POST');
+
+        $this->dispatch(new Fail2BanMatched('login-brute-force', '203.0.113.10', 5, 300, 3, $serverRequest));
+
+        $rows = $this->fetchAllEventRows();
+        self::assertCount(1, $rows);
+        self::assertSame('fail2ban_matched', $rows[0]['event_type']);
+        self::assertSame('login-brute-force', $rows[0]['rule']);
+        self::assertSame(hash('sha256', '203.0.113.10'), $rows[0]['key_hash']);
+        self::assertSame('203.0.113.0', $rows[0]['key_display']);
+        self::assertSame('', $rows[0]['ban_type']);
+        self::assertIsString($rows[0]['meta']);
+        $meta = json_decode($rows[0]['meta'], true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['threshold' => 5, 'period' => 300, 'count' => 3], $meta);
     }
 
     #[Test]

--- a/Tests/Functional/Statistics/EventStatisticsRepositoryTest.php
+++ b/Tests/Functional/Statistics/EventStatisticsRepositoryTest.php
@@ -23,12 +23,13 @@ final class EventStatisticsRepositoryTest extends FunctionalTestCase
         $this->insertEvent('blocklist_matched', 'scanner-paths', 'hash-a', 1000);
         $this->insertEvent('fail2ban_banned', 'login-protection', 'hash-a', 1100);
         $this->insertEvent('throttle_exceeded', 'search-throttle', 'hash-b', 1200);
+        $this->insertEvent('fail2ban_matched', 'login-protection', 'hash-d', 1250);
         $this->insertEvent('safelist_matched', 'office-ips', 'hash-c', 1300);
         $this->insertEvent('blocklist_matched', 'scanner-paths', 'hash-old', 10);
 
         $repository = $this->get(EventStatisticsRepository::class);
 
-        self::assertSame(2, $repository->countDistinctBlockedKeysSince(1000));
+        self::assertSame(3, $repository->countDistinctBlockedKeysSince(1000));
     }
 
     #[Test]
@@ -37,6 +38,7 @@ final class EventStatisticsRepositoryTest extends FunctionalTestCase
         $this->insertEvent('blocklist_matched', 'scanner-paths', 'hash-a', 3600);
         $this->insertEvent('blocklist_matched', 'scanner-paths', 'hash-b', 3700);
         $this->insertEvent('fail2ban_banned', 'login-protection', 'hash-b', 3800);
+        $this->insertEvent('fail2ban_matched', 'login-protection', 'hash-e', 3900);
         $this->insertEvent('throttle_exceeded', 'search-throttle', 'hash-c', 7300);
         $this->insertEvent('safelist_matched', 'office-ips', 'hash-d', 7400);
 
@@ -44,7 +46,7 @@ final class EventStatisticsRepositoryTest extends FunctionalTestCase
 
         self::assertSame(
             [
-                3600 => ['blocklist_matched' => 2, 'fail2ban_banned' => 1],
+                3600 => ['blocklist_matched' => 2, 'fail2ban_banned' => 1, 'fail2ban_matched' => 1],
                 7200 => ['throttle_exceeded' => 1],
             ],
             $repository->countBlockingEventsPerBucketAndType(0, 3600)

--- a/Tests/Functional/Widgets/WidgetDataProviderTest.php
+++ b/Tests/Functional/Widgets/WidgetDataProviderTest.php
@@ -83,15 +83,16 @@ final class WidgetDataProviderTest extends FunctionalTestCase
         $this->insertEvent('hash-a', $startOfToday + 60);
         $this->insertEvent('hash-a', $startOfToday + 120);
         $this->insertEvent('hash-b', $startOfToday + 180);
+        $this->insertEvent('hash-c', $startOfToday + 240, 'fail2ban_matched');
         $this->insertEvent('hash-yesterday', $startOfToday - 3600);
 
-        self::assertSame(2, $this->get(BlockedTodayDataProvider::class)->getNumber());
+        self::assertSame(3, $this->get(BlockedTodayDataProvider::class)->getNumber());
     }
 
-    private function insertEvent(string $keyHash, int $createdAt): void
+    private function insertEvent(string $keyHash, int $createdAt, string $eventType = 'blocklist_matched'): void
     {
         $this->getConnectionPool()->getConnectionForTable(EventLogger::TABLE_NAME)->insert(EventLogger::TABLE_NAME, [
-            'event_type' => 'blocklist_matched',
+            'event_type' => $eventType,
             'rule' => 'scanner-paths',
             'key_hash' => $keyHash,
             'created_at' => $createdAt,

--- a/Tests/Unit/Statistics/BarChartBuilderTest.php
+++ b/Tests/Unit/Statistics/BarChartBuilderTest.php
@@ -65,7 +65,7 @@ final class BarChartBuilderTest extends TestCase
     public function segmentsStackBottomUpInFixedTypeOrder(): void
     {
         $chart = (new BarChartBuilder())->build(
-            [0 => ['fail2ban_banned' => 25, 'blocklist_matched' => 50, 'throttle_exceeded' => 25]],
+            [0 => ['fail2ban_banned' => 25, 'blocklist_matched' => 50, 'throttle_exceeded' => 25, 'fail2ban_matched' => 25]],
             0,
             0,
             3600,
@@ -74,11 +74,12 @@ final class BarChartBuilderTest extends TestCase
 
         $segments = $chart['bars'][0]['segments'];
         self::assertSame(
-            ['blocklist_matched', 'throttle_exceeded', 'fail2ban_banned'],
+            ['blocklist_matched', 'throttle_exceeded', 'fail2ban_matched', 'fail2ban_banned'],
             array_column($segments, 'type')
         );
         self::assertGreaterThan($segments[1]['y'], $segments[0]['y']);
         self::assertGreaterThan($segments[2]['y'], $segments[1]['y']);
+        self::assertGreaterThan($segments[3]['y'], $segments[2]['y']);
         self::assertEqualsWithDelta($chart['baselineY'], $segments[0]['y'] + $segments[0]['height'], 0.11);
     }
 
@@ -87,7 +88,7 @@ final class BarChartBuilderTest extends TestCase
     {
         $barChartBuilder = new BarChartBuilder();
         $allTypes = $barChartBuilder->build(
-            [0 => ['blocklist_matched' => 1, 'throttle_exceeded' => 1, 'fail2ban_banned' => 1, 'allow2ban_banned' => 1]],
+            [0 => ['blocklist_matched' => 1, 'throttle_exceeded' => 1, 'fail2ban_matched' => 1, 'fail2ban_banned' => 1, 'allow2ban_banned' => 1]],
             0,
             0,
             3600,
@@ -96,7 +97,7 @@ final class BarChartBuilderTest extends TestCase
         $onlyFail2Ban = $barChartBuilder->build([0 => ['fail2ban_banned' => 3]], 0, 0, 3600, 'H:00');
 
         $colorsByType = array_column($allTypes['bars'][0]['segments'], 'color', 'type');
-        self::assertCount(4, array_unique($colorsByType));
+        self::assertCount(5, array_unique($colorsByType));
         self::assertSame($colorsByType['fail2ban_banned'], $onlyFail2Ban['bars'][0]['segments'][0]['color']);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require": {
 		"php": ">=8.3",
-		"flowd/phirewall": "^0.7.0",
+		"flowd/phirewall": "^0.8.0",
 		"typo3/cms-backend": "^12.4 || ^13.4 || ^14.0",
 		"typo3/cms-core": "^12.4 || ^13.4 || ^14.0"
 	},

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,8 +1,8 @@
 # cat=event log; type=boolean; label=Enable event logging: Store firewall events (blocked requests, bans, throttling, errors) in the database table tx_firewall_event.
 eventLogEnabled = 1
 
-# cat=event log; type=string; label=Logged event types: Comma separated list of event types to log. Available: blocklist_matched, throttle_exceeded, fail2ban_banned, allow2ban_banned, safelist_matched, track_hit, firewall_error. Safelist and track events are high volume and disabled by default.
-eventLogTypes = blocklist_matched,throttle_exceeded,fail2ban_banned,allow2ban_banned,firewall_error
+# cat=event log; type=string; label=Logged event types: Comma-separated list of event types to log. Available: blocklist_matched, throttle_exceeded, fail2ban_matched, fail2ban_banned, allow2ban_banned, safelist_matched, track_hit, firewall_error. Safelist and track events are high volume and disabled by default.
+eventLogTypes = blocklist_matched,throttle_exceeded,fail2ban_matched,fail2ban_banned,allow2ban_banned,firewall_error
 
 # cat=event log; type=int+; label=Retention in days: The console command firewall:eventlog:prune deletes entries older than this many days.
 eventLogRetentionDays = 30


### PR DESCRIPTION
Bump flowd/phirewall to ^0.8.0. Add the fail2ban_matched event type with its listener, Services.yaml tag and default logging, and count it as a blocked attacker in the statistics (blockingTypes, chart color, label). Migrate the login brute-force recipe in Examples to allow2ban with a filter, and correct the Presets and Statistics wording, since a fail2ban rule now blocks every match under 0.8.