### PR TITLE
Add opt-in form flood protection

### DIFF
--- a/Classes/ConfigFactory.php
+++ b/Classes/ConfigFactory.php
@@ -6,6 +6,7 @@ namespace Flowd\Typo3Firewall;
 
 use Flowd\Phirewall\Config;
 use Flowd\Phirewall\Store\InMemoryCache;
+use Flowd\Typo3Firewall\Form\FormFloodSettings;
 use Flowd\Typo3Firewall\Pattern\FileArrayPatternBackend;
 use Flowd\Typo3Firewall\Writer\FileArrayWriter;
 use Psr\Log\LoggerInterface;
@@ -20,6 +21,7 @@ class ConfigFactory
 {
     public function __construct(
         private readonly EventDispatcher $eventDispatcher,
+        private readonly FormFloodSettings $formFloodSettings,
         private readonly ?LoggerInterface $logger = null,
     ) {}
 
@@ -105,7 +107,7 @@ class ConfigFactory
 
     private function getDefaultConfig(): Config
     {
-        return $this->createBaseConfig(new InMemoryCache());
+        return $this->warnAboutNonPersistentStore($this->createBaseConfig(new InMemoryCache()));
     }
 
     /**
@@ -127,7 +129,30 @@ class ConfigFactory
         $fileArrayPatternBackend = new FileArrayPatternBackend($patternPath, new FileArrayWriter($patternPath, $this->logger), $this->logger);
         $config->blocklists->addPatternBackend('typo3-managed-patterns', $fileArrayPatternBackend)->fromBackend('typo3-blocklist', 'typo3-managed-patterns');
 
+        $this->addFormFloodRule($config);
+
         return $config;
+    }
+
+    /**
+     * The default "form-flood" allow2ban rule, fed by the FloodProtectionFinisher
+     * and enabled through the extension configuration. A rule of the same name
+     * in phirewall.php replaces it via the configuration overlay.
+     */
+    private function addFormFloodRule(Config $config): void
+    {
+        if (!$this->formFloodSettings->isEnabled()) {
+            return;
+        }
+
+        $config->allow2ban->add(
+            FormFloodSettings::DEFAULT_RULE_IDENTIFIER,
+            threshold: $this->formFloodSettings->getThreshold(),
+            period: $this->formFloodSettings->getPeriod(),
+            banSeconds: $this->formFloodSettings->getBanSeconds(),
+            // Fed by recorded hits only; the rule never matches a request on its own.
+            filter: static fn(): bool => false,
+        );
     }
 
     public static function getBaseConfigPath(): string

--- a/Classes/Event/FloodProtectionFinisherTriggered.php
+++ b/Classes/Event/FloodProtectionFinisherTriggered.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowd\Typo3Firewall\Event;
+
+/**
+ * Dispatched before the FloodProtectionFinisher reports a submission.
+ * Listeners can change the allow2ban rule the submission counts against,
+ * or set an empty identifier to skip the submission entirely.
+ */
+final class FloodProtectionFinisherTriggered
+{
+    public function __construct(
+        public string $ruleIdentifier,
+    ) {}
+}

--- a/Classes/Form/Finisher/FloodProtectionFinisher.php
+++ b/Classes/Form/Finisher/FloodProtectionFinisher.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowd\Typo3Firewall\Form\Finisher;
+
+use Flowd\Phirewall\Context\RequestContext;
+use Flowd\Typo3Firewall\Event\FloodProtectionFinisherTriggered;
+use Flowd\Typo3Firewall\Form\FormFloodSettings;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Form\Domain\Finishers\AbstractFinisher;
+
+/**
+ * Reports every successfully validated submission of a form to the firewall
+ * as an allow2ban signal, so a client that submits faster than the rule's
+ * threshold gets banned. Unlike honeypot or CAPTCHA (bot-only), this also
+ * catches real visitors hammering a form.
+ *
+ * By default it reports to the "form-flood" rule, so every form using the
+ * finisher shares one counter per client. Set the "ruleIdentifier" finisher
+ * option (in the form editor or the form definition) to report to a different
+ * allow2ban rule instead, giving that form its own counter; the rule must be
+ * defined in phirewall.php. The FloodProtectionFinisherTriggered event can
+ * still override the identifier per submission.
+ *
+ * Inert until a matching allow2ban rule exists: enable the default rule in the
+ * extension configuration, or define one in phirewall.php. Reports to an
+ * unknown rule name are ignored.
+ */
+final class FloodProtectionFinisher extends AbstractFinisher
+{
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+    ) {}
+
+    protected function executeInternal(): void
+    {
+        $requestContext = $this->finisherContext->getRequest()->getAttribute(RequestContext::ATTRIBUTE_NAME);
+        if (!$requestContext instanceof RequestContext) {
+            // The firewall middleware did not run for this request.
+            return;
+        }
+
+        $configuredRuleIdentifier = $this->options['ruleIdentifier'] ?? null;
+        $ruleIdentifier = is_string($configuredRuleIdentifier) && trim($configuredRuleIdentifier) !== ''
+            ? trim($configuredRuleIdentifier)
+            : FormFloodSettings::DEFAULT_RULE_IDENTIFIER;
+
+        $floodProtectionFinisherTriggered = new FloodProtectionFinisherTriggered($ruleIdentifier);
+        $this->eventDispatcher->dispatch($floodProtectionFinisherTriggered);
+
+        $ruleIdentifier = trim($floodProtectionFinisherTriggered->ruleIdentifier);
+        if ($ruleIdentifier === '') {
+            return;
+        }
+
+        // No key: the firewall resolves the client IP through its own,
+        // trusted-proxy aware resolver when it processes the signal.
+        $requestContext->recordHit($ruleIdentifier);
+    }
+}

--- a/Classes/Form/FormFloodSettings.php
+++ b/Classes/Form/FormFloodSettings.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowd\Typo3Firewall\Form;
+
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+/**
+ * Typed access to the form flood protection settings from the extension
+ * configuration.
+ */
+final class FormFloodSettings
+{
+    /**
+     * Name of the allow2ban rule the default form flood protection registers
+     * and the finisher feeds. Shared between ConfigFactory (which registers
+     * the rule) and the finisher (which reports submissions to it).
+     */
+    public const string DEFAULT_RULE_IDENTIFIER = 'form-flood';
+
+    public function __construct(
+        private readonly ExtensionConfiguration $extensionConfiguration,
+    ) {}
+
+    public function isEnabled(): bool
+    {
+        return (bool)$this->getSetting('formFloodEnabled', '0');
+    }
+
+    public function getThreshold(): int
+    {
+        return max(1, (int)$this->getSetting('formFloodThreshold', '5'));
+    }
+
+    public function getPeriod(): int
+    {
+        return max(1, (int)$this->getSetting('formFloodPeriod', '60'));
+    }
+
+    public function getBanSeconds(): int
+    {
+        return max(1, (int)$this->getSetting('formFloodBan', '3600'));
+    }
+
+    private function getSetting(string $settingName, string $default): string
+    {
+        try {
+            $value = $this->extensionConfiguration->get('firewall', $settingName);
+        } catch (\Throwable) {
+            return $default;
+        }
+
+        return is_scalar($value) ? (string)$value : $default;
+    }
+}

--- a/Configuration/Form/FloodProtectionSetup.yaml
+++ b/Configuration/Form/FloodProtectionSetup.yaml
@@ -1,0 +1,38 @@
+TYPO3:
+  CMS:
+    Form:
+      prototypes:
+        standard:
+          formEditor:
+            translationFiles:
+              1780300620: 'EXT:firewall/Resources/Private/Language/locallang.xlf'
+          finishersDefinition:
+            FlowdFirewallFloodProtection:
+              implementationClassName: Flowd\Typo3Firewall\Form\Finisher\FloodProtectionFinisher
+              options:
+                ruleIdentifier: 'form-flood'
+              formEditor:
+                iconIdentifier: form-finisher
+                label: 'finisher.floodProtection.label'
+                predefinedDefaults:
+                  options:
+                    ruleIdentifier: 'form-flood'
+                editors:
+                  100:
+                    identifier: header
+                    templateName: Inspector-FormElementHeaderEditor
+                  200:
+                    identifier: ruleIdentifier
+                    templateName: Inspector-TextEditor
+                    label: 'finisher.floodProtection.ruleIdentifier.label'
+                    fieldExplanationText: 'finisher.floodProtection.ruleIdentifier.fieldExplanationText'
+                    propertyPath: 'options.ruleIdentifier'
+          formElementsDefinition:
+            Form:
+              formEditor:
+                editors:
+                  900:
+                    selectOptions:
+                      1780296610:
+                        value: FlowdFirewallFloodProtection
+                        label: 'finisher.floodProtection.label'

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Flowd\Typo3Firewall\Form\Finisher\FloodProtectionFinisher;
 use Flowd\Typo3Firewall\Widgets\Provider\BlockedTodayDataProvider;
 use Flowd\Typo3Firewall\Widgets\Provider\FirewallEventsChartDataProvider;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -9,22 +10,32 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use TYPO3\CMS\Dashboard\Widgets\BarChartWidget;
 use TYPO3\CMS\Dashboard\Widgets\NumberWithIconWidget;
 use TYPO3\CMS\Dashboard\Widgets\WidgetInterface;
+use TYPO3\CMS\Form\Domain\Finishers\FinisherInterface;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator, ContainerBuilder $containerBuilder): void {
-    // The dashboard widgets are only registered when the optional
-    // typo3/cms-dashboard package is installed. A package check is not
-    // possible here (the package manager is not available during container
-    // compilation) and not needed: when the classes are merely autoloadable
-    // but the extension is inactive, nothing consumes the dashboard.widget
-    // tag and the unused widget services are dropped during compilation.
+    $services = $containerConfigurator->services();
+    $services->defaults()->autowire()->autoconfigure();
+
+    // Services below depend on optional packages and are only registered when
+    // those are installed. A package check is not possible here (the package
+    // manager is not available during container compilation) and not needed:
+    // when the classes are merely autoloadable but the extension is inactive,
+    // nothing consumes their tags and the unused services are dropped during
+    // compilation.
+
+    // typo3/cms-form: EXT:form's autoconfiguration tags the finisher as
+    // form.finisher, which makes it a public prototype service so the form
+    // framework can instantiate it with dependency injection.
+    if (interface_exists(FinisherInterface::class)) {
+        $services->set(FloodProtectionFinisher::class);
+    }
+
+    // typo3/cms-dashboard: the firewall dashboard widgets.
     if (!interface_exists(WidgetInterface::class)) {
         return;
     }
-
-    $services = $containerConfigurator->services();
-    $services->defaults()->autowire()->autoconfigure();
 
     $services->set(FirewallEventsChartDataProvider::class)->public();
     $services->set(BlockedTodayDataProvider::class)->public();

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,9 +6,12 @@ services:
 
     Flowd\Typo3Firewall\:
         resource: '../Classes/*'
-        # Everything under Widgets depends on the optional typo3/cms-dashboard
-        # package and is registered conditionally in Services.php instead.
-        exclude: '../Classes/Widgets/*'
+        # Widgets depends on the optional typo3/cms-dashboard package,
+        # Form/Finisher on the optional typo3/cms-form package; both are
+        # registered conditionally in Services.php instead.
+        exclude:
+            - '../Classes/Widgets/*'
+            - '../Classes/Form/Finisher/*'
 
     Flowd\Phirewall\Middleware:
         autowire: true

--- a/Documentation/FormProtection.rst
+++ b/Documentation/FormProtection.rst
@@ -1,0 +1,123 @@
+..  include:: Includes.txt
+
+=====================
+Form flood protection
+=====================
+
+Ban clients that submit a form faster than a real visitor plausibly would.
+The extension ships a finisher for the TYPO3 Form Framework (``EXT:form``)
+that reports every submission of a form to the firewall. An allow2ban rule
+counts the submissions per client and bans the client once it crosses the
+threshold; the :doc:`middleware <Middleware>` then rejects further requests
+early, before TYPO3 boots.
+
+The finisher counts every *valid* submission, not only suspicious ones:
+finishers run after the form validation, so rejected submissions are not
+counted. Unlike a honeypot or CAPTCHA, which target bots, it also stops
+real visitors who hammer a form. Use it alongside those measures, not
+instead of them.
+
+..  warning::
+
+    An allow2ban ban blocks the client's IP address for the *whole site*, not
+    just the form. Visitors behind a shared IP (company NAT, campus
+    networks) count against the same limit and would be locked out
+    together. Keep the threshold generous enough for that case.
+
+..  note::
+
+    Requirements: ``typo3/cms-form`` must be installed, and the firewall
+    needs a persistent store (see :doc:`Storage`). With the default
+    ``InMemoryCache`` the counters reset on every request and the rule never
+    triggers; the extension logs a warning in that case.
+
+Enable it
+=========
+
+#.  In :guilabel:`Admin Tools > Settings > Extension Configuration >
+    firewall`, enable :guilabel:`form flood protection`. This registers an
+    allow2ban rule named ``form-flood`` with the configured threshold
+    (default 5 submissions), period (default 60 seconds), and ban duration
+    (default 1 hour).
+
+#.  In the form editor, add the :guilabel:`Firewall: flood protection`
+    finisher to each form you want to protect.
+
+Both steps are needed: without the rule, reported submissions are ignored;
+without the finisher, nothing reports. The client is identified by IP
+address, resolved with the same trusted-proxy handling as the rest of the
+firewall (see :doc:`TrustedProxies`).
+
+Replace the default rule
+========================
+
+For full control over the rule, define ``form-flood`` in
+:file:`config/system/phirewall.php` yourself. A rule from the configuration
+file always wins over the generated default:
+
+..  code-block:: php
+
+    $config->allow2ban->add(
+        'form-flood',
+        threshold: 3,
+        period: 120,
+        banSeconds: 7200,
+        // Fed by the finisher; the rule never matches a request on its own.
+        filter: static fn(): bool => false,
+    );
+
+Give a form its own counter
+===========================
+
+By default every form using the finisher reports to the same ``form-flood``
+rule, so their submissions share one counter per client: a visitor filling
+in several different forms counts towards a single limit, and the resulting
+ban applies site-wide. To count a form on its own, point its finisher at a
+separate allow2ban rule.
+
+In the form editor, the :guilabel:`Firewall: flood protection` finisher has a
+:guilabel:`Allow2ban rule identifier` field. Enter a name other than
+``form-flood`` (for example ``contact-form-flood``) to give that form its own
+counter. The rule must exist, so define it in
+:file:`config/system/phirewall.php` (the extension configuration only
+registers the default ``form-flood`` rule):
+
+..  code-block:: php
+
+    $config->allow2ban->add(
+        'contact-form-flood',
+        threshold: 3,
+        period: 120,
+        banSeconds: 7200,
+        // Fed by the finisher; the rule never matches a request on its own.
+        filter: static fn(): bool => false,
+    );
+
+A submission reported to a rule name that is not defined is ignored, so a
+typo in the field silently disables protection for that form; double-check
+the name matches the rule in ``phirewall.php``.
+
+Change the rule from code
+-------------------------
+
+Before a submission is reported, the finisher dispatches the
+:php:`Flowd\Typo3Firewall\Event\FloodProtectionFinisherTriggered` event with
+the rule identifier the finisher resolved (the option above, or the default).
+A listener can change it, for example to derive the rule from the form, or
+set an empty identifier to skip the submission:
+
+..  code-block:: php
+
+    use Flowd\Typo3Firewall\Event\FloodProtectionFinisherTriggered;
+
+    final class UseStricterContactFormRule
+    {
+        public function __invoke(FloodProtectionFinisherTriggered $event): void
+        {
+            $event->ruleIdentifier = 'contact-form-flood';
+        }
+    }
+
+Register the class as an event listener in the :file:`Services.yaml` of
+your site package. The rule it points to must be defined in
+:file:`config/system/phirewall.php`.

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -29,6 +29,7 @@ relates to phirewall.
     Trusted proxies <TrustedProxies>
     Storage <Storage>
     Presets <Presets>
+    Form protection <FormProtection>
     Backend module <BackendModule>
     Statistics <Statistics>
     Examples <Examples>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -467,6 +467,15 @@
       <trans-unit id="bans.search.noResults">
         <source>No blocked keys match your search.</source>
       </trans-unit>
+      <trans-unit id="finisher.floodProtection.label">
+        <source>Firewall: flood protection</source>
+      </trans-unit>
+      <trans-unit id="finisher.floodProtection.ruleIdentifier.label">
+        <source>Allow2ban rule identifier</source>
+      </trans-unit>
+      <trans-unit id="finisher.floodProtection.ruleIdentifier.fieldExplanationText">
+        <source>Name of the allow2ban rule this form's submissions are counted against. Leave at "form-flood" to share the default rule, or enter a custom name to give this form its own counter. A custom rule must be defined in config/system/phirewall.php.</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Tests/Functional/Form/FloodProtectionFinisherRegistrationTest.php
+++ b/Tests/Functional/Form/FloodProtectionFinisherRegistrationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowd\Typo3Firewall\Tests\Functional\Form;
+
+use Flowd\Typo3Firewall\Form\Finisher\FloodProtectionFinisher;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * The form framework instantiates finishers via GeneralUtility::makeInstance(),
+ * which resolves constructor dependencies only for public container services.
+ * Guards the conditional registration in Configuration/Services.php.
+ */
+#[CoversNothing]
+final class FloodProtectionFinisherRegistrationTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'form',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'flowd/typo3-firewall',
+    ];
+
+    #[Test]
+    public function finisherIsAvailableThroughMakeInstanceWithPrototypeScope(): void
+    {
+        $floodProtectionFinisher = GeneralUtility::makeInstance(FloodProtectionFinisher::class);
+        $secondFloodProtectionFinisher = GeneralUtility::makeInstance(FloodProtectionFinisher::class);
+
+        self::assertNotSame($floodProtectionFinisher, $secondFloodProtectionFinisher);
+    }
+}

--- a/Tests/Unit/ConfigFactoryTest.php
+++ b/Tests/Unit/ConfigFactoryTest.php
@@ -6,17 +6,21 @@ namespace Flowd\Typo3Firewall\Tests\Unit;
 
 use Flowd\Phirewall\Store\PdoCache;
 use Flowd\Typo3Firewall\ConfigFactory;
+use Flowd\Typo3Firewall\Form\FormFloodSettings;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\ListenerProviderInterface;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Core\Http\ServerRequest;
 
 #[CoversClass(ConfigFactory::class)]
+#[UsesClass(FormFloodSettings::class)]
 final class ConfigFactoryTest extends TestCase
 {
     private const string CONFIG_WITHOUT_IP_RESOLVER = <<<'PHP'
@@ -254,6 +258,92 @@ final class ConfigFactoryTest extends TestCase
         self::assertSame([], $blocklistOnlyLogger->records);
     }
 
+    #[Test]
+    public function noFormFloodRuleIsRegisteredWhenTheProtectionIsDisabled(): void
+    {
+        vfsStream::setup('config');
+
+        $config = $this->createFactory()->fromFile(vfsStream::url('config/missing.php'));
+
+        self::assertArrayNotHasKey('form-flood', $config->allow2ban->rules());
+    }
+
+    #[Test]
+    public function theFormFloodRuleIsRegisteredWithItsDefaultsWhenEnabled(): void
+    {
+        vfsStream::setup('config');
+        $formFloodSettings = $this->createFormFloodSettings(['formFloodEnabled' => '1']);
+
+        $config = $this->createFactory(formFloodSettings: $formFloodSettings)->fromFile(vfsStream::url('config/missing.php'));
+
+        $rules = $config->allow2ban->rules();
+        self::assertArrayHasKey('form-flood', $rules);
+        self::assertSame(5, $rules['form-flood']->threshold());
+        self::assertSame(60, $rules['form-flood']->period());
+        self::assertSame(3600, $rules['form-flood']->banSeconds());
+    }
+
+    #[Test]
+    public function theFormFloodRuleUsesTheConfiguredThresholdPeriodAndBan(): void
+    {
+        vfsStream::setup('config');
+        $formFloodSettings = $this->createFormFloodSettings([
+            'formFloodEnabled' => '1',
+            'formFloodThreshold' => '7',
+            'formFloodPeriod' => '120',
+            'formFloodBan' => '600',
+        ]);
+
+        $config = $this->createFactory(formFloodSettings: $formFloodSettings)->fromFile(vfsStream::url('config/missing.php'));
+
+        $formFloodRule = $config->allow2ban->rules()['form-flood'];
+        self::assertSame(7, $formFloodRule->threshold());
+        self::assertSame(120, $formFloodRule->period());
+        self::assertSame(600, $formFloodRule->banSeconds());
+    }
+
+    #[Test]
+    public function aFormFloodRuleInTheConfigurationFileWinsOverTheGeneratedDefault(): void
+    {
+        $configPath = $this->writeConfigurationFile(<<<'PHP'
+            <?php
+            use Flowd\Phirewall\Config;
+            use Flowd\Phirewall\Store\InMemoryCache;
+            use Psr\EventDispatcher\EventDispatcherInterface;
+
+            return function (EventDispatcherInterface $eventDispatcher): Config {
+                $config = new Config(new InMemoryCache(), $eventDispatcher);
+                $config->allow2ban->add(
+                    'form-flood',
+                    threshold: 99,
+                    period: 90,
+                    banSeconds: 900,
+                    filter: static fn(): bool => false,
+                );
+                return $config;
+            };
+            PHP);
+        $formFloodSettings = $this->createFormFloodSettings(['formFloodEnabled' => '1', 'formFloodThreshold' => '7']);
+
+        $config = $this->createFactory(formFloodSettings: $formFloodSettings)->fromFile($configPath);
+
+        self::assertSame(99, $config->allow2ban->rules()['form-flood']->threshold());
+    }
+
+    #[Test]
+    public function theDefaultConfigWarnsWhenTheFormFloodRuleRunsOnTheInMemoryStore(): void
+    {
+        vfsStream::setup('config');
+        $spyLogger = $this->createSpyLogger();
+        $formFloodSettings = $this->createFormFloodSettings(['formFloodEnabled' => '1']);
+
+        $this->createFactory($spyLogger, cli: false, formFloodSettings: $formFloodSettings)->fromFile(vfsStream::url('config/missing.php'));
+
+        self::assertCount(1, $spyLogger->records);
+        self::assertSame('warning', $spyLogger->records[0]['level']);
+        self::assertStringContainsString('InMemoryCache', $spyLogger->records[0]['message']);
+    }
+
     /**
      * @return AbstractLogger&object{records: list<array{level: string, message: string}>}
      */
@@ -270,7 +360,7 @@ final class ConfigFactoryTest extends TestCase
         };
     }
 
-    private function createFactory(?LoggerInterface $logger = null, bool $cli = true): ConfigFactory
+    private function createFactory(?LoggerInterface $logger = null, bool $cli = true, ?FormFloodSettings $formFloodSettings = null): ConfigFactory
     {
         $listenerProvider = new class () implements ListenerProviderInterface {
             /**
@@ -282,10 +372,12 @@ final class ConfigFactoryTest extends TestCase
             }
         };
 
-        return new class (new EventDispatcher($listenerProvider), $logger, $cli) extends ConfigFactory {
-            public function __construct(EventDispatcher $eventDispatcher, ?LoggerInterface $logger, private readonly bool $cli)
+        $formFloodSettings ??= $this->createFormFloodSettings([]);
+
+        return new class (new EventDispatcher($listenerProvider), $formFloodSettings, $logger, $cli) extends ConfigFactory {
+            public function __construct(EventDispatcher $eventDispatcher, FormFloodSettings $formFloodSettings, ?LoggerInterface $logger, private readonly bool $cli)
             {
-                parent::__construct($eventDispatcher, $logger);
+                parent::__construct($eventDispatcher, $formFloodSettings, $logger);
             }
 
             protected function isCliRequest(): bool
@@ -293,6 +385,26 @@ final class ConfigFactoryTest extends TestCase
                 return $this->cli;
             }
         };
+    }
+
+    /**
+     * @param array<string, string> $settings
+     */
+    private function createFormFloodSettings(array $settings): FormFloodSettings
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturnCallback(
+            static function (string $extension, string $path) use ($settings): string {
+                self::assertSame('firewall', $extension);
+                if (!isset($settings[$path])) {
+                    throw new \RuntimeException('Setting not configured: ' . $path, 1770000003);
+                }
+
+                return $settings[$path];
+            }
+        );
+
+        return new FormFloodSettings($extensionConfiguration);
     }
 
     private function writeConfigurationFile(string $content): string

--- a/Tests/Unit/Event/FloodProtectionFinisherTriggeredTest.php
+++ b/Tests/Unit/Event/FloodProtectionFinisherTriggeredTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowd\Typo3Firewall\Tests\Unit\Event;
+
+use Flowd\Typo3Firewall\Event\FloodProtectionFinisherTriggered;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FloodProtectionFinisherTriggered::class)]
+final class FloodProtectionFinisherTriggeredTest extends TestCase
+{
+    #[Test]
+    public function exposesTheRuleIdentifierPassedToTheConstructor(): void
+    {
+        $floodProtectionFinisherTriggered = new FloodProtectionFinisherTriggered('form-flood');
+
+        self::assertSame('form-flood', $floodProtectionFinisherTriggered->ruleIdentifier);
+    }
+
+    #[Test]
+    public function ruleIdentifierIsMutableSoListenersCanOverrideIt(): void
+    {
+        $floodProtectionFinisherTriggered = new FloodProtectionFinisherTriggered('form-flood');
+        $floodProtectionFinisherTriggered->ruleIdentifier = 'custom-rule';
+
+        self::assertSame('custom-rule', $floodProtectionFinisherTriggered->ruleIdentifier);
+    }
+}

--- a/Tests/Unit/Fixtures/RecordingEventDispatcher.php
+++ b/Tests/Unit/Fixtures/RecordingEventDispatcher.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowd\Typo3Firewall\Tests\Unit\Fixtures;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Records dispatched events and optionally mutates them like a real
+ * listener would.
+ */
+final class RecordingEventDispatcher implements EventDispatcherInterface
+{
+    public int $dispatchCount = 0;
+
+    public ?object $lastEvent = null;
+
+    /** @var (\Closure(object): void)|null */
+    public ?\Closure $mutator = null;
+
+    public function dispatch(object $event): object
+    {
+        $this->dispatchCount++;
+        $this->lastEvent = $event;
+
+        if ($this->mutator instanceof \Closure) {
+            ($this->mutator)($event);
+        }
+
+        return $event;
+    }
+}

--- a/Tests/Unit/Form/Finisher/FloodProtectionFinisherTest.php
+++ b/Tests/Unit/Form/Finisher/FloodProtectionFinisherTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowd\Typo3Firewall\Tests\Unit\Form\Finisher;
+
+use Flowd\Phirewall\BanType;
+use Flowd\Phirewall\Context\RequestContext;
+use Flowd\Phirewall\Http\FirewallResult;
+use Flowd\Typo3Firewall\Event\FloodProtectionFinisherTriggered;
+use Flowd\Typo3Firewall\Form\Finisher\FloodProtectionFinisher;
+use Flowd\Typo3Firewall\Form\FormFloodSettings;
+use Flowd\Typo3Firewall\Tests\Unit\Fixtures\RecordingEventDispatcher;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Mvc\Request;
+use TYPO3\CMS\Form\Domain\Finishers\FinisherContext;
+
+#[CoversClass(FloodProtectionFinisher::class)]
+#[UsesClass(FloodProtectionFinisherTriggered::class)]
+final class FloodProtectionFinisherTest extends TestCase
+{
+    #[Test]
+    public function recordsTheSubmissionForTheDefaultRule(): void
+    {
+        $recordingEventDispatcher = new RecordingEventDispatcher();
+        $requestContext = new RequestContext(FirewallResult::pass());
+
+        $this->execute($recordingEventDispatcher, $requestContext);
+
+        self::assertSame(1, $recordingEventDispatcher->dispatchCount);
+        self::assertInstanceOf(FloodProtectionFinisherTriggered::class, $recordingEventDispatcher->lastEvent);
+
+        $recordedSignals = $requestContext->getRecordedSignals();
+        self::assertCount(1, $recordedSignals);
+        self::assertSame(FormFloodSettings::DEFAULT_RULE_IDENTIFIER, $recordedSignals[0]->ruleName);
+        self::assertSame(BanType::Allow2Ban, $recordedSignals[0]->banType);
+        self::assertNull($recordedSignals[0]->key);
+    }
+
+    #[Test]
+    public function recordsAgainstTheRuleIdentifierFromTheFinisherOption(): void
+    {
+        $recordingEventDispatcher = new RecordingEventDispatcher();
+        $requestContext = new RequestContext(FirewallResult::pass());
+
+        $this->execute($recordingEventDispatcher, $requestContext, ['ruleIdentifier' => 'contact-form-flood']);
+
+        self::assertSame('contact-form-flood', $requestContext->getRecordedSignals()[0]->ruleName);
+    }
+
+    #[Test]
+    public function blankRuleIdentifierOptionFallsBackToTheDefaultRule(): void
+    {
+        $recordingEventDispatcher = new RecordingEventDispatcher();
+        $requestContext = new RequestContext(FirewallResult::pass());
+
+        $this->execute($recordingEventDispatcher, $requestContext, ['ruleIdentifier' => '   ']);
+
+        self::assertSame(FormFloodSettings::DEFAULT_RULE_IDENTIFIER, $requestContext->getRecordedSignals()[0]->ruleName);
+    }
+
+    #[Test]
+    public function withoutFirewallRequestContextNothingIsDispatchedOrRecorded(): void
+    {
+        $recordingEventDispatcher = new RecordingEventDispatcher();
+
+        $this->execute($recordingEventDispatcher, null);
+
+        self::assertSame(0, $recordingEventDispatcher->dispatchCount);
+    }
+
+    #[Test]
+    public function listenerCanOverrideTheRuleIdentifier(): void
+    {
+        $recordingEventDispatcher = new RecordingEventDispatcher();
+        $recordingEventDispatcher->mutator = static function (object $event): void {
+            self::assertInstanceOf(FloodProtectionFinisherTriggered::class, $event);
+            $event->ruleIdentifier = 'contact-form-flood';
+        };
+        $requestContext = new RequestContext(FirewallResult::pass());
+
+        $this->execute($recordingEventDispatcher, $requestContext);
+
+        self::assertSame('contact-form-flood', $requestContext->getRecordedSignals()[0]->ruleName);
+    }
+
+    #[Test]
+    public function listenerCanSkipTheSubmissionWithABlankRuleIdentifier(): void
+    {
+        $recordingEventDispatcher = new RecordingEventDispatcher();
+        $recordingEventDispatcher->mutator = static function (object $event): void {
+            self::assertInstanceOf(FloodProtectionFinisherTriggered::class, $event);
+            $event->ruleIdentifier = '   ';
+        };
+        $requestContext = new RequestContext(FirewallResult::pass());
+
+        $this->execute($recordingEventDispatcher, $requestContext);
+
+        self::assertSame(1, $recordingEventDispatcher->dispatchCount);
+        self::assertFalse($requestContext->hasRecordedSignals());
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function execute(RecordingEventDispatcher $recordingEventDispatcher, ?RequestContext $requestContext, array $options = []): void
+    {
+        $serverRequest = (new ServerRequest('https://example.com/'))
+            ->withAttribute('extbase', new ExtbaseRequestParameters());
+
+        if ($requestContext instanceof RequestContext) {
+            $serverRequest = $serverRequest->withAttribute(RequestContext::ATTRIBUTE_NAME, $requestContext);
+        }
+
+        $finisherContext = $this->createMock(FinisherContext::class);
+        $finisherContext->method('getRequest')->willReturn(new Request($serverRequest));
+
+        $floodProtectionFinisher = new FloodProtectionFinisher($recordingEventDispatcher);
+        $floodProtectionFinisher->setOptions($options);
+        $floodProtectionFinisher->execute($finisherContext);
+    }
+}

--- a/Tests/Unit/Form/FormFloodSettingsTest.php
+++ b/Tests/Unit/Form/FormFloodSettingsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowd\Typo3Firewall\Tests\Unit\Form;
+
+use Flowd\Typo3Firewall\Form\FormFloodSettings;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+#[CoversClass(FormFloodSettings::class)]
+final class FormFloodSettingsTest extends TestCase
+{
+    #[Test]
+    public function protectionIsDisabledByDefault(): void
+    {
+        self::assertFalse($this->createSettings([])->isEnabled());
+    }
+
+    #[Test]
+    public function protectionCanBeEnabled(): void
+    {
+        self::assertTrue($this->createSettings(['formFloodEnabled' => '1'])->isEnabled());
+    }
+
+    #[Test]
+    public function thresholdPeriodAndBanFallbackToTheirDefaults(): void
+    {
+        $formFloodSettings = $this->createSettings([]);
+
+        self::assertSame(5, $formFloodSettings->getThreshold());
+        self::assertSame(60, $formFloodSettings->getPeriod());
+        self::assertSame(3600, $formFloodSettings->getBanSeconds());
+    }
+
+    #[Test]
+    public function configuredValuesAreUsed(): void
+    {
+        $formFloodSettings = $this->createSettings([
+            'formFloodThreshold' => '7',
+            'formFloodPeriod' => '120',
+            'formFloodBan' => '600',
+        ]);
+
+        self::assertSame(7, $formFloodSettings->getThreshold());
+        self::assertSame(120, $formFloodSettings->getPeriod());
+        self::assertSame(600, $formFloodSettings->getBanSeconds());
+    }
+
+    #[Test]
+    public function valuesNeverGoBelowOne(): void
+    {
+        $formFloodSettings = $this->createSettings([
+            'formFloodThreshold' => '0',
+            'formFloodPeriod' => '-5',
+            'formFloodBan' => 'not-a-number',
+        ]);
+
+        self::assertSame(1, $formFloodSettings->getThreshold());
+        self::assertSame(1, $formFloodSettings->getPeriod());
+        self::assertSame(1, $formFloodSettings->getBanSeconds());
+    }
+
+    /**
+     * @param array<string, string> $settings
+     */
+    private function createSettings(array $settings): FormFloodSettings
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturnCallback(
+            static function (string $extension, string $path) use ($settings): string {
+                self::assertSame('firewall', $extension);
+                if (!isset($settings[$path])) {
+                    throw new \RuntimeException('Setting not configured: ' . $path, 1770000002);
+                }
+
+                return $settings[$path];
+            }
+        );
+
+        return new FormFloodSettings($extensionConfiguration);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
 		"tomasvotruba/cognitive-complexity": "^1.2.0",
 		"tomasvotruba/type-coverage": "^2.2.1",
 		"typo3/cms-dashboard": "^12.4 || ^13.4 || ^14.0",
+		"typo3/cms-form": "^12.4 || ^13.4 || ^14.0",
 		"typo3/coding-standards": "^0.8.0",
 		"typo3/testing-framework": "^8.3.1 || ^9.5.0"
 	},
@@ -57,7 +58,8 @@
 		"flowd/phirewall-preset-bad-ips": "Block requests from known-bad IPs using a bundled public-domain threat-intelligence feed snapshot",
 		"flowd/phirewall-preset-bots": "Block AI crawlers and rate-limit aggressive SEO bots with curated user-agent presets",
 		"flowd/phirewall-preset-owasp-crs": "OWASP CRS detection (SQL injection, XSS, ...): the SecRule engine plus per-paranoia-level presets",
-		"typo3/cms-dashboard": "Adds firewall dashboard widgets (blocked attackers, events chart)"
+		"typo3/cms-dashboard": "Adds firewall dashboard widgets (blocked attackers, events chart)",
+		"typo3/cms-form": "Adds the flood-protection form finisher that bans clients hammering a form"
 	},
 	"autoload": {
 		"psr-4": {

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -9,3 +9,15 @@ eventLogRetentionDays = 30
 
 # cat=event log; type=boolean; label=Anonymize IP addresses: Store client IPs with the last IPv4 octet (or the IPv6 host part) removed.
 eventLogAnonymizeIp = 1
+
+# cat=form flood protection; type=boolean; label=Enable form flood protection: Register a default "form-flood" allow2ban rule, fed by the "Firewall: flood protection" form finisher. Needs a persistent store (APCu/Redis) configured in phirewall.php.
+formFloodEnabled = 0
+
+# cat=form flood protection; type=int+; label=Threshold: Number of submissions within the period before the client is banned.
+formFloodThreshold = 5
+
+# cat=form flood protection; type=int+; label=Period in seconds: Time window in which submissions are counted.
+formFloodPeriod = 60
+
+# cat=form flood protection; type=int+; label=Ban duration in seconds: How long the client stays banned once the threshold is exceeded.
+formFloodBan = 3600

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+defined('TYPO3') or die();
+
+if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('form')) {
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(
+        'plugin.tx_form.settings.yamlConfigurations.1780296610 = EXT:firewall/Configuration/Form/FloodProtectionSetup.yaml
+module.tx_form.settings.yamlConfigurations.1780296610 = EXT:firewall/Configuration/Form/FloodProtectionSetup.yaml'
+    );
+}


### PR DESCRIPTION
A FloodProtectionFinisher for EXT:form reports every submission to the firewall as an allow2ban signal. ConfigFactory registers a default form-flood allow2ban rule when enabled through the extension configuration; a rule of the same name in phirewall.php wins through the overlay. The FloodProtectionFinisherTriggered event lets listeners change the rule per submission or skip it.