### PR TITLE
Log the phirewall banned-key block events

### DIFF
--- a/Classes/Backend/Controller/FirewallController.php
+++ b/Classes/Backend/Controller/FirewallController.php
@@ -158,11 +158,11 @@ class FirewallController extends ActionController
         return $moduleTemplate->renderResponse('Backend/Firewall/Bans');
     }
 
-    public function eventsAction(string $type = '', string $search = ''): ResponseInterface
+    public function eventsAction(string $type = '', string $search = '', int $page = 1): ResponseInterface
     {
         $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
         $this->addModuleMenu($moduleTemplate, 'events');
-        $moduleTemplate->assignMultiple($this->eventLogViewDataProvider->getViewData($type, trim($search)));
+        $moduleTemplate->assignMultiple($this->eventLogViewDataProvider->getViewData($type, trim($search), $page));
 
         return $moduleTemplate->renderResponse('Backend/Firewall/Events');
     }

--- a/Classes/Backend/Controller/FirewallController.php
+++ b/Classes/Backend/Controller/FirewallController.php
@@ -11,6 +11,7 @@ use Flowd\Phirewall\Pattern\PatternKind;
 use Flowd\Phirewall\Store\InMemoryCache;
 use Flowd\Typo3Firewall\ConfigFactory;
 use Flowd\Typo3Firewall\Dto\PatternEntryDto;
+use Flowd\Typo3Firewall\EventLog\EventLogViewDataProvider;
 use Flowd\Typo3Firewall\Pattern\FileArrayPatternBackend;
 use Flowd\Typo3Firewall\Pattern\PatternValidationException;
 use Flowd\Typo3Firewall\Statistics\StatisticsViewDataProvider;
@@ -48,6 +49,7 @@ class FirewallController extends ActionController
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
         private readonly Config $config,
         private readonly StatisticsViewDataProvider $statisticsViewDataProvider,
+        private readonly EventLogViewDataProvider $eventLogViewDataProvider,
         private readonly ?LoggerInterface $logger = null,
     ) {}
 
@@ -156,6 +158,15 @@ class FirewallController extends ActionController
         return $moduleTemplate->renderResponse('Backend/Firewall/Bans');
     }
 
+    public function eventsAction(string $type = '', string $search = ''): ResponseInterface
+    {
+        $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
+        $this->addModuleMenu($moduleTemplate, 'events');
+        $moduleTemplate->assignMultiple($this->eventLogViewDataProvider->getViewData($type, trim($search)));
+
+        return $moduleTemplate->renderResponse('Backend/Firewall/Events');
+    }
+
     public function statisticsAction(string $range = ''): ResponseInterface
     {
         $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
@@ -226,6 +237,7 @@ class FirewallController extends ActionController
         $items = [
             'overview' => 'nav.patterns',
             'bans' => 'nav.bans',
+            'events' => 'nav.events',
             'statistics' => 'nav.statistics',
         ];
 

--- a/Classes/EventLog/EventLogRepository.php
+++ b/Classes/EventLog/EventLogRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flowd\Typo3Firewall\EventLog;
 
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 
 /**
  * Reads event log entries for the backend module.
@@ -16,11 +17,11 @@ final class EventLogRepository
     ) {}
 
     /**
-     * Latest events, newest first, with the meta JSON decoded to an array.
+     * A page of events, newest first, with the meta JSON decoded to an array.
      *
      * @return list<array<string, mixed>>
      */
-    public function findLatest(string $eventType = '', string $search = '', int $limit = 100): array
+    public function findLatest(string $eventType = '', string $search = '', int $limit = 100, int $offset = 0): array
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(EventLogger::TABLE_NAME);
         $queryBuilder
@@ -28,8 +29,36 @@ final class EventLogRepository
             ->from(EventLogger::TABLE_NAME)
             ->orderBy('created_at', 'DESC')
             ->addOrderBy('uid', 'DESC')
-            ->setMaxResults($limit);
+            ->setMaxResults($limit)
+            ->setFirstResult($offset);
+        $this->applyFilters($queryBuilder, $eventType, $search);
 
+        $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
+
+        return array_map(static function (array $row): array {
+            $row['meta'] = self::decodeMeta($row['meta'] ?? null);
+            return $row;
+        }, $rows);
+    }
+
+    /**
+     * Number of events matching the given filters.
+     */
+    public function count(string $eventType = '', string $search = ''): int
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(EventLogger::TABLE_NAME);
+        $queryBuilder
+            ->count('*')
+            ->from(EventLogger::TABLE_NAME);
+        $this->applyFilters($queryBuilder, $eventType, $search);
+
+        $count = $queryBuilder->executeQuery()->fetchOne();
+
+        return is_numeric($count) ? (int)$count : 0;
+    }
+
+    private function applyFilters(QueryBuilder $queryBuilder, string $eventType, string $search): void
+    {
         if ($eventType !== '') {
             $queryBuilder->andWhere(
                 $queryBuilder->expr()->eq('event_type', $queryBuilder->createNamedParameter($eventType)),
@@ -44,13 +73,6 @@ final class EventLogRepository
                 $queryBuilder->expr()->like('request_path', $queryBuilder->createNamedParameter($likeValue)),
             ));
         }
-
-        $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
-
-        return array_map(static function (array $row): array {
-            $row['meta'] = self::decodeMeta($row['meta'] ?? null);
-            return $row;
-        }, $rows);
     }
 
     /**

--- a/Classes/EventLog/EventLogRepository.php
+++ b/Classes/EventLog/EventLogRepository.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowd\Typo3Firewall\EventLog;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Reads event log entries for the backend module.
+ */
+final class EventLogRepository
+{
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+    ) {}
+
+    /**
+     * Latest events, newest first, with the meta JSON decoded to an array.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function findLatest(string $eventType = '', string $search = '', int $limit = 100): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(EventLogger::TABLE_NAME);
+        $queryBuilder
+            ->select('*')
+            ->from(EventLogger::TABLE_NAME)
+            ->orderBy('created_at', 'DESC')
+            ->addOrderBy('uid', 'DESC')
+            ->setMaxResults($limit);
+
+        if ($eventType !== '') {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->eq('event_type', $queryBuilder->createNamedParameter($eventType)),
+            );
+        }
+
+        if ($search !== '') {
+            $likeValue = '%' . $queryBuilder->escapeLikeWildcards($search) . '%';
+            $queryBuilder->andWhere($queryBuilder->expr()->or(
+                $queryBuilder->expr()->like('rule', $queryBuilder->createNamedParameter($likeValue)),
+                $queryBuilder->expr()->like('key_display', $queryBuilder->createNamedParameter($likeValue)),
+                $queryBuilder->expr()->like('request_path', $queryBuilder->createNamedParameter($likeValue)),
+            ));
+        }
+
+        $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
+
+        return array_map(static function (array $row): array {
+            $row['meta'] = self::decodeMeta($row['meta'] ?? null);
+            return $row;
+        }, $rows);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function decodeMeta(mixed $rawMeta): array
+    {
+        if (!is_string($rawMeta) || $rawMeta === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($rawMeta, true, 8, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return [];
+        }
+
+        return is_array($decoded) ? $decoded : [];
+    }
+}

--- a/Classes/EventLog/EventLogViewDataProvider.php
+++ b/Classes/EventLog/EventLogViewDataProvider.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowd\Typo3Firewall\EventLog;
+
+/**
+ * Assembles the view data for the event log module view.
+ */
+final class EventLogViewDataProvider
+{
+    private const int EVENT_LIST_LIMIT = 100;
+
+    public function __construct(
+        private readonly EventLogRepository $eventLogRepository,
+        private readonly EventLogSettings $eventLogSettings,
+    ) {}
+
+    /**
+     * View variables for the event log view; unknown types fall back to all types.
+     *
+     * @return array<string, mixed>
+     */
+    public function getViewData(string $type, string $search): array
+    {
+        $eventType = FirewallEventType::tryFrom($type);
+        $currentType = $eventType instanceof FirewallEventType ? $eventType->value : '';
+
+        $events = array_map(function (array $event): array {
+            $event['metaLines'] = $this->flattenMeta(is_array($event['meta']) ? $event['meta'] : []);
+            return $event;
+        }, $this->eventLogRepository->findLatest($currentType, $search, self::EVENT_LIST_LIMIT));
+
+        return [
+            'events' => $events,
+            'eventTypes' => FirewallEventType::cases(),
+            'currentType' => $currentType,
+            'search' => $search,
+            'loggingEnabled' => $this->eventLogSettings->isEnabled(),
+            'limit' => self::EVENT_LIST_LIMIT,
+        ];
+    }
+
+    /**
+     * Flatten a decoded meta array into "key: value" display lines; nested keys
+     * are joined with a dot (e.g. "diagnosticHeaders.X-Phirewall-Owasp-Rule: 942100").
+     *
+     * @param array<mixed> $meta
+     * @return list<string>
+     */
+    private function flattenMeta(array $meta, string $prefix = ''): array
+    {
+        $lines = [];
+        foreach ($meta as $key => $value) {
+            $label = $prefix === '' ? (string)$key : $prefix . '.' . $key;
+            if (is_array($value)) {
+                $lines = [...$lines, ...$this->flattenMeta($value, $label)];
+                continue;
+            }
+
+            $lines[] = $label . ': ' . (is_scalar($value) ? (string)$value : (string)json_encode($value));
+        }
+
+        return $lines;
+    }
+}

--- a/Classes/EventLog/EventLogViewDataProvider.php
+++ b/Classes/EventLog/EventLogViewDataProvider.php
@@ -9,7 +9,7 @@ namespace Flowd\Typo3Firewall\EventLog;
  */
 final class EventLogViewDataProvider
 {
-    private const int EVENT_LIST_LIMIT = 100;
+    private const int ITEMS_PER_PAGE = 50;
 
     public function __construct(
         private readonly EventLogRepository $eventLogRepository,
@@ -17,19 +17,24 @@ final class EventLogViewDataProvider
     ) {}
 
     /**
-     * View variables for the event log view; unknown types fall back to all types.
+     * View variables for the event log view; unknown types fall back to all
+     * types, out-of-range pages are clamped.
      *
      * @return array<string, mixed>
      */
-    public function getViewData(string $type, string $search): array
+    public function getViewData(string $type, string $search, int $page = 1): array
     {
         $eventType = FirewallEventType::tryFrom($type);
         $currentType = $eventType instanceof FirewallEventType ? $eventType->value : '';
 
+        $totalCount = $this->eventLogRepository->count($currentType, $search);
+        $pageCount = max(1, (int)ceil($totalCount / self::ITEMS_PER_PAGE));
+        $page = min(max(1, $page), $pageCount);
+
         $events = array_map(function (array $event): array {
             $event['metaLines'] = $this->flattenMeta(is_array($event['meta']) ? $event['meta'] : []);
             return $event;
-        }, $this->eventLogRepository->findLatest($currentType, $search, self::EVENT_LIST_LIMIT));
+        }, $this->eventLogRepository->findLatest($currentType, $search, self::ITEMS_PER_PAGE, ($page - 1) * self::ITEMS_PER_PAGE));
 
         return [
             'events' => $events,
@@ -37,7 +42,15 @@ final class EventLogViewDataProvider
             'currentType' => $currentType,
             'search' => $search,
             'loggingEnabled' => $this->eventLogSettings->isEnabled(),
-            'limit' => self::EVENT_LIST_LIMIT,
+            'pagination' => [
+                'currentPage' => $page,
+                'pageCount' => $pageCount,
+                'totalCount' => $totalCount,
+                'hasPrevious' => $page > 1,
+                'hasNext' => $page < $pageCount,
+                'previousPage' => max(1, $page - 1),
+                'nextPage' => min($pageCount, $page + 1),
+            ],
         ];
     }
 

--- a/Classes/EventLog/EventLogger.php
+++ b/Classes/EventLog/EventLogger.php
@@ -27,7 +27,7 @@ final class EventLogger
     ) {}
 
     /**
-     * @param array<string, int|string|null> $meta
+     * @param array<string, int|string|array<string, string>|null> $meta
      */
     public function log(
         FirewallEventType $firewallEventType,
@@ -54,7 +54,7 @@ final class EventLogger
                 'request_path' => mb_substr($serverRequest->getUri()->getPath(), 0, 2048),
                 'request_method' => mb_substr($serverRequest->getMethod(), 0, 10),
                 'user_agent' => mb_substr($serverRequest->getHeaderLine('User-Agent'), 0, 255),
-                'meta' => json_encode(array_filter($meta, static fn(int|string|null $value): bool => $value !== null), JSON_THROW_ON_ERROR),
+                'meta' => json_encode(array_filter($meta, static fn(int|string|array|null $value): bool => $value !== null && $value !== []), JSON_THROW_ON_ERROR),
                 'created_at' => time(),
             ]);
         } catch (\Throwable $throwable) {

--- a/Classes/EventLog/FirewallEventLogListener.php
+++ b/Classes/EventLog/FirewallEventLogListener.php
@@ -39,7 +39,7 @@ final class FirewallEventLogListener
 
     public function onBlocklistMatched(BlocklistMatched $blocklistMatched): void
     {
-        $this->eventLogger->log(FirewallEventType::BlocklistMatched, $blocklistMatched->serverRequest, rule: $blocklistMatched->rule, meta: $this->diagnosticMeta($blocklistMatched->matchResult ?? null));
+        $this->eventLogger->log(FirewallEventType::BlocklistMatched, $blocklistMatched->serverRequest, rule: $blocklistMatched->rule, meta: $this->diagnosticMeta($blocklistMatched->matchResult));
     }
 
     public function onThrottleExceeded(ThrottleExceeded $throttleExceeded): void
@@ -49,7 +49,7 @@ final class FirewallEventLogListener
             'period' => $throttleExceeded->period,
             'count' => $throttleExceeded->count,
             'retryAfter' => $throttleExceeded->retryAfter,
-            ...$this->diagnosticMeta($throttleExceeded->matchResult ?? null),
+            ...$this->diagnosticMeta($throttleExceeded->matchResult),
         ]);
     }
 
@@ -59,7 +59,7 @@ final class FirewallEventLogListener
             'threshold' => $fail2BanMatched->threshold,
             'period' => $fail2BanMatched->period,
             'count' => $fail2BanMatched->count,
-            ...$this->diagnosticMeta($fail2BanMatched->matchResult ?? null),
+            ...$this->diagnosticMeta($fail2BanMatched->matchResult),
         ]);
     }
 
@@ -70,7 +70,7 @@ final class FirewallEventLogListener
             'period' => $fail2BanBanned->period,
             'banSeconds' => $fail2BanBanned->banSeconds,
             'count' => $fail2BanBanned->count,
-            ...$this->diagnosticMeta($fail2BanBanned->matchResult ?? null),
+            ...$this->diagnosticMeta($fail2BanBanned->matchResult),
         ]);
     }
 
@@ -86,7 +86,7 @@ final class FirewallEventLogListener
             'period' => $allow2BanBanned->period,
             'banSeconds' => $allow2BanBanned->banSeconds,
             'count' => $allow2BanBanned->count,
-            ...$this->diagnosticMeta($allow2BanBanned->matchResult ?? null),
+            ...$this->diagnosticMeta($allow2BanBanned->matchResult),
         ]);
     }
 
@@ -97,7 +97,7 @@ final class FirewallEventLogListener
 
     public function onSafelistMatched(SafelistMatched $safelistMatched): void
     {
-        $this->eventLogger->log(FirewallEventType::SafelistMatched, $safelistMatched->serverRequest, rule: $safelistMatched->rule, meta: $this->diagnosticMeta($safelistMatched->matchResult ?? null));
+        $this->eventLogger->log(FirewallEventType::SafelistMatched, $safelistMatched->serverRequest, rule: $safelistMatched->rule, meta: $this->diagnosticMeta($safelistMatched->matchResult));
     }
 
     public function onTrackHit(TrackHit $trackHit): void
@@ -106,7 +106,7 @@ final class FirewallEventLogListener
             'period' => $trackHit->period,
             'count' => $trackHit->count,
             'limit' => $trackHit->limit,
-            ...$this->diagnosticMeta($trackHit->matchResult ?? null),
+            ...$this->diagnosticMeta($trackHit->matchResult),
         ]);
     }
 
@@ -119,8 +119,8 @@ final class FirewallEventLogListener
     }
 
     /**
-     * Extract the matcher's diagnostic headers as a meta fragment. Events from
-     * phirewall versions without the matchResult property yield no fragment.
+     * Extract the matcher's diagnostic headers as a meta fragment. Null on the
+     * signal-path events (no matcher ran) and on any match without diagnostics.
      *
      * @return array<string, array<string, string>>
      */

--- a/Classes/EventLog/FirewallEventLogListener.php
+++ b/Classes/EventLog/FirewallEventLogListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flowd\Typo3Firewall\EventLog;
 
 use Flowd\Phirewall\BanType;
+use Flowd\Phirewall\Config\MatchResult;
 use Flowd\Phirewall\Events\Allow2BanBanned;
 use Flowd\Phirewall\Events\Allow2BanBlocked;
 use Flowd\Phirewall\Events\BlocklistMatched;
@@ -28,7 +29,7 @@ use Flowd\Phirewall\Events\TrackHit;
  * One public method per phirewall event; the method count grows with the
  * event catalog, not with complexity.
  *
- * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ * @SuppressWarnings("PHPMD.TooManyPublicMethods")
  */
 final class FirewallEventLogListener
 {
@@ -38,7 +39,7 @@ final class FirewallEventLogListener
 
     public function onBlocklistMatched(BlocklistMatched $blocklistMatched): void
     {
-        $this->eventLogger->log(FirewallEventType::BlocklistMatched, $blocklistMatched->serverRequest, rule: $blocklistMatched->rule);
+        $this->eventLogger->log(FirewallEventType::BlocklistMatched, $blocklistMatched->serverRequest, rule: $blocklistMatched->rule, meta: $this->diagnosticMeta($blocklistMatched->matchResult ?? null));
     }
 
     public function onThrottleExceeded(ThrottleExceeded $throttleExceeded): void
@@ -48,6 +49,7 @@ final class FirewallEventLogListener
             'period' => $throttleExceeded->period,
             'count' => $throttleExceeded->count,
             'retryAfter' => $throttleExceeded->retryAfter,
+            ...$this->diagnosticMeta($throttleExceeded->matchResult ?? null),
         ]);
     }
 
@@ -57,6 +59,7 @@ final class FirewallEventLogListener
             'threshold' => $fail2BanMatched->threshold,
             'period' => $fail2BanMatched->period,
             'count' => $fail2BanMatched->count,
+            ...$this->diagnosticMeta($fail2BanMatched->matchResult ?? null),
         ]);
     }
 
@@ -67,6 +70,7 @@ final class FirewallEventLogListener
             'period' => $fail2BanBanned->period,
             'banSeconds' => $fail2BanBanned->banSeconds,
             'count' => $fail2BanBanned->count,
+            ...$this->diagnosticMeta($fail2BanBanned->matchResult ?? null),
         ]);
     }
 
@@ -82,6 +86,7 @@ final class FirewallEventLogListener
             'period' => $allow2BanBanned->period,
             'banSeconds' => $allow2BanBanned->banSeconds,
             'count' => $allow2BanBanned->count,
+            ...$this->diagnosticMeta($allow2BanBanned->matchResult ?? null),
         ]);
     }
 
@@ -92,7 +97,7 @@ final class FirewallEventLogListener
 
     public function onSafelistMatched(SafelistMatched $safelistMatched): void
     {
-        $this->eventLogger->log(FirewallEventType::SafelistMatched, $safelistMatched->serverRequest, rule: $safelistMatched->rule);
+        $this->eventLogger->log(FirewallEventType::SafelistMatched, $safelistMatched->serverRequest, rule: $safelistMatched->rule, meta: $this->diagnosticMeta($safelistMatched->matchResult ?? null));
     }
 
     public function onTrackHit(TrackHit $trackHit): void
@@ -101,6 +106,7 @@ final class FirewallEventLogListener
             'period' => $trackHit->period,
             'count' => $trackHit->count,
             'limit' => $trackHit->limit,
+            ...$this->diagnosticMeta($trackHit->matchResult ?? null),
         ]);
     }
 
@@ -110,5 +116,28 @@ final class FirewallEventLogListener
             'exceptionClass' => $firewallError->exception::class,
             'exceptionMessage' => mb_substr($firewallError->exception->getMessage(), 0, 500),
         ]);
+    }
+
+    /**
+     * Extract the matcher's diagnostic headers as a meta fragment. Events from
+     * phirewall versions without the matchResult property yield no fragment.
+     *
+     * @return array<string, array<string, string>>
+     */
+    private function diagnosticMeta(?MatchResult $matchResult): array
+    {
+        $headers = $matchResult?->metadata()['diagnostic_headers'] ?? null;
+        if (!is_array($headers)) {
+            return [];
+        }
+
+        $stringHeaders = [];
+        foreach ($headers as $name => $value) {
+            if (is_string($name) && is_scalar($value)) {
+                $stringHeaders[$name] = (string)$value;
+            }
+        }
+
+        return $stringHeaders === [] ? [] : ['diagnosticHeaders' => $stringHeaders];
     }
 }

--- a/Classes/EventLog/FirewallEventLogListener.php
+++ b/Classes/EventLog/FirewallEventLogListener.php
@@ -6,8 +6,10 @@ namespace Flowd\Typo3Firewall\EventLog;
 
 use Flowd\Phirewall\BanType;
 use Flowd\Phirewall\Events\Allow2BanBanned;
+use Flowd\Phirewall\Events\Allow2BanBlocked;
 use Flowd\Phirewall\Events\BlocklistMatched;
 use Flowd\Phirewall\Events\Fail2BanBanned;
+use Flowd\Phirewall\Events\Fail2BanBlocked;
 use Flowd\Phirewall\Events\Fail2BanMatched;
 use Flowd\Phirewall\Events\FirewallError;
 use Flowd\Phirewall\Events\SafelistMatched;
@@ -22,6 +24,11 @@ use Flowd\Phirewall\Events\TrackHit;
  *
  * PerformanceMeasured is intentionally not logged: it fires on every
  * request and would turn the log into a request log.
+ *
+ * One public method per phirewall event; the method count grows with the
+ * event catalog, not with complexity.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
 final class FirewallEventLogListener
 {
@@ -63,6 +70,11 @@ final class FirewallEventLogListener
         ]);
     }
 
+    public function onFail2BanBlocked(Fail2BanBlocked $fail2BanBlocked): void
+    {
+        $this->eventLogger->log(FirewallEventType::Fail2BanBlocked, $fail2BanBlocked->serverRequest, rule: $fail2BanBlocked->rule, key: $fail2BanBlocked->key, banType: BanType::Fail2Ban->value);
+    }
+
     public function onAllow2BanBanned(Allow2BanBanned $allow2BanBanned): void
     {
         $this->eventLogger->log(FirewallEventType::Allow2BanBanned, $allow2BanBanned->serverRequest, rule: $allow2BanBanned->rule, key: $allow2BanBanned->key, banType: BanType::Allow2Ban->value, meta: [
@@ -71,6 +83,11 @@ final class FirewallEventLogListener
             'banSeconds' => $allow2BanBanned->banSeconds,
             'count' => $allow2BanBanned->count,
         ]);
+    }
+
+    public function onAllow2BanBlocked(Allow2BanBlocked $allow2BanBlocked): void
+    {
+        $this->eventLogger->log(FirewallEventType::Allow2BanBlocked, $allow2BanBlocked->serverRequest, rule: $allow2BanBlocked->rule, key: $allow2BanBlocked->key, banType: BanType::Allow2Ban->value);
     }
 
     public function onSafelistMatched(SafelistMatched $safelistMatched): void

--- a/Classes/EventLog/FirewallEventType.php
+++ b/Classes/EventLog/FirewallEventType.php
@@ -14,7 +14,11 @@ enum FirewallEventType: string
 
     case Fail2BanBanned = 'fail2ban_banned';
 
+    case Fail2BanBlocked = 'fail2ban_blocked';
+
     case Allow2BanBanned = 'allow2ban_banned';
+
+    case Allow2BanBlocked = 'allow2ban_blocked';
 
     case SafelistMatched = 'safelist_matched';
 
@@ -29,6 +33,6 @@ enum FirewallEventType: string
      */
     public static function blockingTypes(): array
     {
-        return [self::BlocklistMatched, self::ThrottleExceeded, self::Fail2BanMatched, self::Fail2BanBanned, self::Allow2BanBanned];
+        return [self::BlocklistMatched, self::ThrottleExceeded, self::Fail2BanMatched, self::Fail2BanBanned, self::Fail2BanBlocked, self::Allow2BanBanned, self::Allow2BanBlocked];
     }
 }

--- a/Classes/Statistics/BarChartBuilder.php
+++ b/Classes/Statistics/BarChartBuilder.php
@@ -46,6 +46,8 @@ final class BarChartBuilder
         FirewallEventType::Fail2BanMatched->value => '#d55e00',
         FirewallEventType::Fail2BanBanned->value => '#eda100',
         FirewallEventType::Allow2BanBanned->value => '#008300',
+        FirewallEventType::Fail2BanBlocked->value => '#cc79a7',
+        FirewallEventType::Allow2BanBlocked->value => '#56b4e9',
     ];
 
     /**

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -14,7 +14,7 @@ return [
         'extensionName' => 'firewall',
         'inheritNavigationComponentFromMainModule' => false,
         'controllerActions' => [
-            FirewallController::class => ['overview', 'create', 'delete', 'prune', 'update', 'bans', 'unban', 'statistics'],
+            FirewallController::class => ['overview', 'create', 'delete', 'prune', 'update', 'bans', 'unban', 'events', 'statistics'],
         ],
     ],
 ];

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -44,8 +44,14 @@ services:
               identifier: 'firewall-event-log/fail2ban-banned'
               method: 'onFail2BanBanned'
             - name: event.listener
+              identifier: 'firewall-event-log/fail2ban-blocked'
+              method: 'onFail2BanBlocked'
+            - name: event.listener
               identifier: 'firewall-event-log/allow2ban-banned'
               method: 'onAllow2BanBanned'
+            - name: event.listener
+              identifier: 'firewall-event-log/allow2ban-blocked'
+              method: 'onAllow2BanBlocked'
             - name: event.listener
               identifier: 'firewall-event-log/safelist-matched'
               method: 'onSafelistMatched'

--- a/Documentation/BackendModule.rst
+++ b/Documentation/BackendModule.rst
@@ -7,11 +7,12 @@ Backend module
 The extension adds a backend module under **System** >
 **Firewall**. It is available to administrators only.
 
-The module has three views. Switch between them with the **View**
+The module has four views. Switch between them with the **View**
 dropdown in the module's doc-header:
 
 - **Patterns** manages the static block patterns.
 - **Blocked keys** lists the clients that rules have banned automatically.
+- **Event log** lists the recorded firewall events with their details.
 - **Statistics** shows how much traffic the firewall blocked over time.
 
 Patterns
@@ -123,8 +124,31 @@ matching request.
 
 Blocklist matches do not appear here. A blocklist rule answers each matching
 request with a 403 response on the spot and keeps no ban, so there is nothing
-to list. To see blocklist activity, use the event log and the
-:doc:`Statistics` view.
+to list. To see blocklist activity, use the :ref:`Event log <backend-module-event-log>`
+and the :doc:`Statistics` view.
+
+..  _backend-module-event-log:
+
+Event log
+=========
+
+This view lists the latest recorded firewall events, newest first. Every
+entry shows the time, the event type, the rule, the key (an anonymized IP
+address, or a hash for sensitive keys), the request line with the user
+agent, and the event details.
+
+The details column renders everything the event carried as ``key: value``
+lines, including counters (``threshold``, ``count``, ``banSeconds``) and the
+diagnostic headers a matcher attached to its match, for example
+``diagnosticHeaders.X-Phirewall-Owasp-Rule: 942100`` for an OWASP CRS match.
+The diagnostics land in the log independently of the
+``X-Phirewall-*`` response headers, so you can inspect which rule fired
+without exposing that information to clients.
+
+Filter the list by event type with the dropdown, or search across rule
+names, keys, and request paths. The view shows the latest 100 entries;
+narrow the filter to find older events, and see :doc:`Statistics` for the
+retention settings of the underlying log table.
 
 Statistics
 ==========

--- a/Documentation/BackendModule.rst
+++ b/Documentation/BackendModule.rst
@@ -146,8 +146,8 @@ The diagnostics land in the log independently of the
 without exposing that information to clients.
 
 Filter the list by event type with the dropdown, or search across rule
-names, keys, and request paths. The view shows the latest 100 entries;
-narrow the filter to find older events, and see :doc:`Statistics` for the
+names, keys, and request paths. The list is paginated with 50 entries per
+page; the pager keeps the active filter. See :doc:`Statistics` for the
 retention settings of the underlying log table.
 
 Statistics

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -287,8 +287,26 @@
       <trans-unit id="events.table.details">
         <source>Details</source>
       </trans-unit>
-      <trans-unit id="events.limitNote">
-        <source>Showing the latest %1$s events.</source>
+      <trans-unit id="events.pagination.label">
+        <source>Event log pages</source>
+      </trans-unit>
+      <trans-unit id="events.pagination.total">
+        <source>%1$s events</source>
+      </trans-unit>
+      <trans-unit id="events.pagination.page">
+        <source>Page %1$s of %2$s</source>
+      </trans-unit>
+      <trans-unit id="events.pagination.first">
+        <source>First page</source>
+      </trans-unit>
+      <trans-unit id="events.pagination.previous">
+        <source>Previous page</source>
+      </trans-unit>
+      <trans-unit id="events.pagination.next">
+        <source>Next page</source>
+      </trans-unit>
+      <trans-unit id="events.pagination.last">
+        <source>Last page</source>
       </trans-unit>
       <trans-unit id="bans.title">
         <source>Currently blocked keys</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -401,8 +401,14 @@
       <trans-unit id="statistics.type.fail2ban_banned">
         <source>Fail2Ban bans</source>
       </trans-unit>
+      <trans-unit id="statistics.type.fail2ban_blocked">
+        <source>Fail2Ban ban blocks</source>
+      </trans-unit>
       <trans-unit id="statistics.type.allow2ban_banned">
         <source>Allow2Ban bans</source>
+      </trans-unit>
+      <trans-unit id="statistics.type.allow2ban_blocked">
+        <source>Allow2Ban ban blocks</source>
       </trans-unit>
       <trans-unit id="statistics.type.safelist_matched">
         <source>Safelist matches</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -239,6 +239,57 @@
       <trans-unit id="nav.bans">
         <source>Blocked keys</source>
       </trans-unit>
+      <trans-unit id="nav.events">
+        <source>Event log</source>
+      </trans-unit>
+      <trans-unit id="events.title">
+        <source>Firewall events</source>
+      </trans-unit>
+      <trans-unit id="events.disabled">
+        <source>Event logging is disabled. Enable it in the extension configuration to record events.</source>
+      </trans-unit>
+      <trans-unit id="events.empty">
+        <source>No events recorded.</source>
+      </trans-unit>
+      <trans-unit id="events.filter.type">
+        <source>Event type</source>
+      </trans-unit>
+      <trans-unit id="events.filter.allTypes">
+        <source>All types</source>
+      </trans-unit>
+      <trans-unit id="events.filter.submit">
+        <source>Filter</source>
+      </trans-unit>
+      <trans-unit id="events.filter.reset">
+        <source>Reset</source>
+      </trans-unit>
+      <trans-unit id="events.search.label">
+        <source>Search</source>
+      </trans-unit>
+      <trans-unit id="events.search.placeholder">
+        <source>Rule, key or path …</source>
+      </trans-unit>
+      <trans-unit id="events.table.time">
+        <source>Time</source>
+      </trans-unit>
+      <trans-unit id="events.table.type">
+        <source>Type</source>
+      </trans-unit>
+      <trans-unit id="events.table.rule">
+        <source>Rule</source>
+      </trans-unit>
+      <trans-unit id="events.table.key">
+        <source>Key</source>
+      </trans-unit>
+      <trans-unit id="events.table.request">
+        <source>Request</source>
+      </trans-unit>
+      <trans-unit id="events.table.details">
+        <source>Details</source>
+      </trans-unit>
+      <trans-unit id="events.limitNote">
+        <source>Showing the latest %1$s events.</source>
+      </trans-unit>
       <trans-unit id="bans.title">
         <source>Currently blocked keys</source>
       </trans-unit>

--- a/Resources/Private/Templates/Backend/Firewall/Events.html
+++ b/Resources/Private/Templates/Backend/Firewall/Events.html
@@ -1,0 +1,120 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+<f:layout name="Module" />
+
+<f:section name="Content">
+    <f:flashMessages />
+
+    <f:if condition="!{loggingEnabled}">
+        <div class="alert alert-warning">
+            <core:icon identifier="actions-exclamation" size="small" />
+            <f:translate key="events.disabled" />
+        </div>
+    </f:if>
+
+    <div class="card mb-4">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <span>
+                <core:icon identifier="actions-list" size="small" />
+                <strong><f:translate key="events.title" /></strong>
+            </span>
+        </div>
+        <div class="card-body">
+            <f:form action="events" method="post" class="row row-cols-lg-auto g-2 align-items-center m-0">
+                <div class="col-12">
+                    <label class="visually-hidden" for="events-type"><f:translate key="events.filter.type" /></label>
+                    <select id="events-type" name="type" class="form-select form-select-sm">
+                        <option value=""><f:translate key="events.filter.allTypes" /></option>
+                        <f:for each="{eventTypes}" as="eventTypeOption">
+                            <option value="{eventTypeOption.value}" {f:if(condition: '{eventTypeOption.value} == {currentType}', then: 'selected="selected"')}><f:translate key="statistics.type.{eventTypeOption.value}" /></option>
+                        </f:for>
+                    </select>
+                </div>
+                <div class="col-12">
+                    <label class="visually-hidden" for="events-search"><f:translate key="events.search.label" /></label>
+                    <f:form.textfield id="events-search" name="search" value="{search}" class="form-control form-control-sm" placeholder="{f:translate(key: 'events.search.placeholder')}" />
+                </div>
+                <div class="col-12">
+                    <f:form.button class="btn btn-sm btn-default" type="submit">
+                        <core:icon identifier="actions-search" size="small" />
+                        <f:translate key="events.filter.submit" />
+                    </f:form.button>
+                    <f:if condition="{search} || {currentType}">
+                        <a class="btn btn-sm btn-link" href="{f:uri.action(action: 'events')}"><f:translate key="events.filter.reset" /></a>
+                    </f:if>
+                </div>
+            </f:form>
+        </div>
+
+        <f:if condition="{events}">
+            <f:then>
+                <div class="table-fit mb-0">
+                    <table class="table table-striped table-hover mb-0">
+                        <thead>
+                            <tr>
+                                <th scope="col"><f:translate key="events.table.time" /></th>
+                                <th scope="col"><f:translate key="events.table.type" /></th>
+                                <th scope="col"><f:translate key="events.table.rule" /></th>
+                                <th scope="col"><f:translate key="events.table.key" /></th>
+                                <th scope="col"><f:translate key="events.table.request" /></th>
+                                <th scope="col"><f:translate key="events.table.details" /></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <f:for each="{events}" as="event">
+                                <tr>
+                                    <td class="text-nowrap"><f:format.date format="Y-m-d H:i:s">@{event.created_at}</f:format.date></td>
+                                    <td>
+                                        <span class="badge bg-secondary"><f:translate key="statistics.type.{event.event_type}" /></span>
+                                        <f:if condition="{event.ban_type}">
+                                            <span class="badge bg-warning">{event.ban_type}</span>
+                                        </f:if>
+                                    </td>
+                                    <td><code class="text-break">{event.rule}</code></td>
+                                    <td>
+                                        <f:if condition="{event.key_display}">
+                                            <f:then><code class="text-break">{event.key_display}</code></f:then>
+                                            <f:else>
+                                                <f:if condition="{event.key_hash}">
+                                                    <span class="text-muted font-monospace" title="{event.key_hash}"><f:format.crop maxCharacters="12" append="…">{event.key_hash}</f:format.crop></span>
+                                                </f:if>
+                                            </f:else>
+                                        </f:if>
+                                    </td>
+                                    <td>
+                                        <code class="text-break">{event.request_method} {event.request_host}{event.request_path}</code>
+                                        <f:if condition="{event.user_agent}">
+                                            <br /><small class="text-muted text-break">{event.user_agent}</small>
+                                        </f:if>
+                                    </td>
+                                    <td>
+                                        <f:if condition="{event.metaLines}">
+                                            <ul class="list-unstyled mb-0">
+                                                <f:for each="{event.metaLines}" as="metaLine">
+                                                    <li><small><code class="text-break">{metaLine}</code></small></li>
+                                                </f:for>
+                                            </ul>
+                                        </f:if>
+                                    </td>
+                                </tr>
+                            </f:for>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="card-footer text-muted">
+                    <small><f:translate key="events.limitNote" arguments="{0: limit}" /></small>
+                </div>
+            </f:then>
+            <f:else>
+                <div class="card-body pt-0">
+                    <p class="text-muted mb-0">
+                        <core:icon identifier="actions-info" size="small" />
+                        <f:translate key="events.empty" />
+                    </p>
+                </div>
+            </f:else>
+        </f:if>
+    </div>
+</f:section>
+</html>

--- a/Resources/Private/Templates/Backend/Firewall/Events.html
+++ b/Resources/Private/Templates/Backend/Firewall/Events.html
@@ -102,8 +102,33 @@
                         </tbody>
                     </table>
                 </div>
-                <div class="card-footer text-muted">
-                    <small><f:translate key="events.limitNote" arguments="{0: limit}" /></small>
+                <div class="card-footer d-flex justify-content-between align-items-center">
+                    <small class="text-muted"><f:translate key="events.pagination.total" arguments="{0: pagination.totalCount}" /></small>
+                    <f:if condition="{pagination.pageCount} > 1">
+                        <nav aria-label="{f:translate(key: 'events.pagination.label')}">
+                            <ul class="pagination pagination-sm mb-0">
+                                <f:if condition="{pagination.hasPrevious}">
+                                    <li class="page-item">
+                                        <a class="page-link" href="{f:uri.action(action: 'events', arguments: {type: currentType, search: search, page: 1})}" title="{f:translate(key: 'events.pagination.first')}">«</a>
+                                    </li>
+                                    <li class="page-item">
+                                        <a class="page-link" href="{f:uri.action(action: 'events', arguments: {type: currentType, search: search, page: pagination.previousPage})}" title="{f:translate(key: 'events.pagination.previous')}">‹</a>
+                                    </li>
+                                </f:if>
+                                <li class="page-item disabled">
+                                    <span class="page-link"><f:translate key="events.pagination.page" arguments="{0: pagination.currentPage, 1: pagination.pageCount}" /></span>
+                                </li>
+                                <f:if condition="{pagination.hasNext}">
+                                    <li class="page-item">
+                                        <a class="page-link" href="{f:uri.action(action: 'events', arguments: {type: currentType, search: search, page: pagination.nextPage})}" title="{f:translate(key: 'events.pagination.next')}">›</a>
+                                    </li>
+                                    <li class="page-item">
+                                        <a class="page-link" href="{f:uri.action(action: 'events', arguments: {type: currentType, search: search, page: pagination.pageCount})}" title="{f:translate(key: 'events.pagination.last')}">»</a>
+                                    </li>
+                                </f:if>
+                            </ul>
+                        </nav>
+                    </f:if>
                 </div>
             </f:then>
             <f:else>

--- a/Tests/Functional/Backend/Controller/FirewallControllerTest.php
+++ b/Tests/Functional/Backend/Controller/FirewallControllerTest.php
@@ -334,6 +334,34 @@ final class FirewallControllerTest extends FunctionalTestCase
     }
 
     #[Test]
+    public function eventsActionPaginatesOlderEventsOntoTheNextPage(): void
+    {
+        $this->setUpConfigWithFail2BanRule();
+        $connection = $this->getConnectionPool()->getConnectionForTable('tx_firewall_event');
+        $now = time();
+        $connection->insert('tx_firewall_event', [
+            'event_type' => 'blocklist_matched',
+            'rule' => 'oldest-entry',
+            'created_at' => $now - 1000,
+        ]);
+        for ($i = 0; $i < 50; ++$i) {
+            $connection->insert('tx_firewall_event', [
+                'event_type' => 'blocklist_matched',
+                'rule' => 'filler-' . $i,
+                'created_at' => $now,
+            ]);
+        }
+
+        $firstPage = (string)$this->dispatchModuleRequest('events')->getBody();
+        self::assertStringNotContainsString('oldest-entry', $firstPage);
+        self::assertStringContainsString('Page 1 of 2', $firstPage);
+
+        $secondPage = (string)$this->dispatchModuleRequest('events', ['page' => '2'])->getBody();
+        self::assertStringContainsString('oldest-entry', $secondPage);
+        self::assertStringNotContainsString('filler-0', $secondPage);
+    }
+
+    #[Test]
     public function unbanActionRemovesTheBan(): void
     {
         $config = $this->setUpConfigWithFail2BanRule();

--- a/Tests/Functional/Backend/Controller/FirewallControllerTest.php
+++ b/Tests/Functional/Backend/Controller/FirewallControllerTest.php
@@ -286,6 +286,54 @@ final class FirewallControllerTest extends FunctionalTestCase
     }
 
     #[Test]
+    public function eventsActionListsEventsWithFlattenedMeta(): void
+    {
+        $this->setUpConfigWithFail2BanRule();
+        $this->getConnectionPool()->getConnectionForTable('tx_firewall_event')->insert('tx_firewall_event', [
+            'event_type' => 'blocklist_matched',
+            'rule' => 'preset.owasp-crs.blocklist',
+            'key_display' => '203.0.113.0',
+            'key_hash' => hash('sha256', '203.0.113.10'),
+            'request_host' => 'example.com',
+            'request_path' => '/probe',
+            'request_method' => 'GET',
+            'user_agent' => 'scanner/1.0',
+            'meta' => '{"diagnosticHeaders":{"X-Phirewall-Owasp-Rule":"942100"}}',
+            'created_at' => time(),
+        ]);
+
+        $response = $this->dispatchModuleRequest('events');
+        $body = (string)$response->getBody();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('preset.owasp-crs.blocklist', $body);
+        self::assertStringContainsString('diagnosticHeaders.X-Phirewall-Owasp-Rule: 942100', $body);
+        self::assertStringContainsString('scanner/1.0', $body);
+    }
+
+    #[Test]
+    public function eventsActionFiltersByEventType(): void
+    {
+        $this->setUpConfigWithFail2BanRule();
+        $connection = $this->getConnectionPool()->getConnectionForTable('tx_firewall_event');
+        $connection->insert('tx_firewall_event', [
+            'event_type' => 'blocklist_matched',
+            'rule' => 'scanner-paths',
+            'created_at' => time(),
+        ]);
+        $connection->insert('tx_firewall_event', [
+            'event_type' => 'track_hit',
+            'rule' => 'observed-endpoint',
+            'created_at' => time(),
+        ]);
+
+        $body = (string)$this->dispatchModuleRequest('events', ['type' => 'track_hit'])->getBody();
+
+        self::assertStringContainsString('observed-endpoint', $body);
+        self::assertStringNotContainsString('scanner-paths', $body);
+    }
+
+    #[Test]
     public function unbanActionRemovesTheBan(): void
     {
         $config = $this->setUpConfigWithFail2BanRule();

--- a/Tests/Functional/EventLog/EventLogTest.php
+++ b/Tests/Functional/EventLog/EventLogTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flowd\Typo3Firewall\Tests\Functional\EventLog;
 
+use Flowd\Phirewall\Config\MatchResult;
 use Flowd\Phirewall\Events\Allow2BanBlocked;
 use Flowd\Phirewall\Events\BlocklistMatched;
 use Flowd\Phirewall\Events\Fail2BanBlocked;
@@ -13,6 +14,8 @@ use Flowd\Phirewall\Events\SafelistMatched;
 use Flowd\Phirewall\Events\ThrottleExceeded;
 use Flowd\Typo3Firewall\Command\PruneEventLogCommand;
 use Flowd\Typo3Firewall\EventLog\EventLogger;
+use Flowd\Typo3Firewall\EventLog\EventLogSettings;
+use Flowd\Typo3Firewall\EventLog\FirewallEventType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -35,7 +38,7 @@ final class EventLogTest extends FunctionalTestCase
         $serverRequest = (new ServerRequest('https://example.com/wp-admin/setup.php', 'GET'))
             ->withAddedHeader('User-Agent', 'sqlmap/1.0');
 
-        $this->dispatch(new BlocklistMatched('scanner-paths', $serverRequest));
+        $this->dispatch(new BlocklistMatched('scanner-paths', $serverRequest, MatchResult::matched('custom')));
 
         $rows = $this->fetchAllEventRows();
         self::assertCount(1, $rows);
@@ -53,7 +56,7 @@ final class EventLogTest extends FunctionalTestCase
     {
         $serverRequest = new ServerRequest('https://example.com/search', 'GET');
 
-        $this->dispatch(new ThrottleExceeded('search-throttle', '203.0.113.10', 10, 60, 11, 42, $serverRequest));
+        $this->dispatch(new ThrottleExceeded('search-throttle', '203.0.113.10', 10, 60, 11, 42, $serverRequest, null));
 
         $rows = $this->fetchAllEventRows();
         self::assertCount(1, $rows);
@@ -70,7 +73,7 @@ final class EventLogTest extends FunctionalTestCase
     {
         $serverRequest = new ServerRequest('https://example.com/api', 'GET');
 
-        $this->dispatch(new ThrottleExceeded('api-throttle', 'secret-api-key', 10, 60, 11, 42, $serverRequest));
+        $this->dispatch(new ThrottleExceeded('api-throttle', 'secret-api-key', 10, 60, 11, 42, $serverRequest, null));
 
         $rows = $this->fetchAllEventRows();
         self::assertCount(1, $rows);
@@ -84,7 +87,7 @@ final class EventLogTest extends FunctionalTestCase
     {
         $serverRequest = new ServerRequest('https://example.com/login', 'POST');
 
-        $this->dispatch(new Fail2BanMatched('login-brute-force', '203.0.113.10', 5, 300, 3, $serverRequest));
+        $this->dispatch(new Fail2BanMatched('login-brute-force', '203.0.113.10', 5, 300, 3, $serverRequest, MatchResult::matched('custom')));
 
         $rows = $this->fetchAllEventRows();
         self::assertCount(1, $rows);
@@ -137,6 +140,26 @@ final class EventLogTest extends FunctionalTestCase
     }
 
     #[Test]
+    public function nestedDiagnosticHeadersMetaIsPersisted(): void
+    {
+        $serverRequest = new ServerRequest('https://example.com/probe', 'GET');
+        $eventLogger = new EventLogger(
+            $this->getConnectionPool(),
+            new EventLogSettings($this->get(ExtensionConfiguration::class)),
+        );
+
+        $eventLogger->log(FirewallEventType::BlocklistMatched, $serverRequest, rule: 'crs', meta: [
+            'diagnosticHeaders' => ['X-Phirewall-Owasp-Rule' => '942100'],
+        ]);
+
+        $rows = $this->fetchAllEventRows();
+        self::assertCount(1, $rows);
+        self::assertIsString($rows[0]['meta']);
+        $meta = json_decode($rows[0]['meta'], true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['diagnosticHeaders' => ['X-Phirewall-Owasp-Rule' => '942100']], $meta);
+    }
+
+    #[Test]
     public function firewallErrorEventStoresTheExceptionSummary(): void
     {
         $serverRequest = new ServerRequest('https://example.com/', 'GET');
@@ -156,7 +179,7 @@ final class EventLogTest extends FunctionalTestCase
     #[Test]
     public function safelistEventsAreNotLoggedByDefault(): void
     {
-        $this->dispatch(new SafelistMatched('office-ips', new ServerRequest('https://example.com/', 'GET')));
+        $this->dispatch(new SafelistMatched('office-ips', new ServerRequest('https://example.com/', 'GET'), MatchResult::matched('custom')));
 
         self::assertSame([], $this->fetchAllEventRows());
     }
@@ -166,7 +189,7 @@ final class EventLogTest extends FunctionalTestCase
     {
         $this->get(ExtensionConfiguration::class)->set('firewall', ['eventLogEnabled' => '0']);
 
-        $this->dispatch(new BlocklistMatched('scanner-paths', new ServerRequest('https://example.com/', 'GET')));
+        $this->dispatch(new BlocklistMatched('scanner-paths', new ServerRequest('https://example.com/', 'GET'), MatchResult::matched('custom')));
 
         self::assertSame([], $this->fetchAllEventRows());
     }

--- a/Tests/Functional/EventLog/EventLogTest.php
+++ b/Tests/Functional/EventLog/EventLogTest.php
@@ -28,6 +28,9 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 #[CoversClass(EventLogger::class)]
 final class EventLogTest extends FunctionalTestCase
 {
+    /** Mirrors the eventLogTypes default in ext_conf_template.txt. */
+    private const string DEFAULT_EVENT_LOG_TYPES = 'blocklist_matched,throttle_exceeded,fail2ban_matched,fail2ban_banned,allow2ban_banned,firewall_error';
+
     protected array $testExtensionsToLoad = [
         'flowd/typo3-firewall',
     ];
@@ -104,9 +107,10 @@ final class EventLogTest extends FunctionalTestCase
     #[Test]
     public function fail2BanBlockedEventStoresTheBanType(): void
     {
-        if (!class_exists(Fail2BanBlocked::class)) {
-            self::markTestSkipped('Requires a phirewall version that ships Fail2BanBlocked.');
-        }
+        // Banned-key blocks are high-volume, so they are off by default. Keep
+        // the shipped default types too: ExtensionConfiguration state leaks
+        // into later tests in this class, which rely on the defaults.
+        $this->get(ExtensionConfiguration::class)->set('firewall', ['eventLogEnabled' => '1', 'eventLogTypes' => self::DEFAULT_EVENT_LOG_TYPES . ',fail2ban_blocked']);
 
         $serverRequest = new ServerRequest('https://example.com/login', 'POST');
 
@@ -124,9 +128,10 @@ final class EventLogTest extends FunctionalTestCase
     #[Test]
     public function allow2BanBlockedEventStoresTheBanType(): void
     {
-        if (!class_exists(Allow2BanBlocked::class)) {
-            self::markTestSkipped('Requires a phirewall version that ships Allow2BanBlocked.');
-        }
+        // Banned-key blocks are high-volume, so they are off by default. Keep
+        // the shipped default types too: ExtensionConfiguration state leaks
+        // into later tests in this class, which rely on the defaults.
+        $this->get(ExtensionConfiguration::class)->set('firewall', ['eventLogEnabled' => '1', 'eventLogTypes' => self::DEFAULT_EVENT_LOG_TYPES . ',allow2ban_blocked']);
 
         $serverRequest = new ServerRequest('https://example.com/form', 'POST');
 

--- a/Tests/Functional/EventLog/EventLogTest.php
+++ b/Tests/Functional/EventLog/EventLogTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Flowd\Typo3Firewall\Tests\Functional\EventLog;
 
-use Flowd\Phirewall\Config\MatchResult;
+use Flowd\Phirewall\Events\Allow2BanBlocked;
 use Flowd\Phirewall\Events\BlocklistMatched;
+use Flowd\Phirewall\Events\Fail2BanBlocked;
 use Flowd\Phirewall\Events\Fail2BanMatched;
 use Flowd\Phirewall\Events\FirewallError;
 use Flowd\Phirewall\Events\SafelistMatched;
@@ -34,7 +35,7 @@ final class EventLogTest extends FunctionalTestCase
         $serverRequest = (new ServerRequest('https://example.com/wp-admin/setup.php', 'GET'))
             ->withAddedHeader('User-Agent', 'sqlmap/1.0');
 
-        $this->dispatch(new BlocklistMatched('scanner-paths', $serverRequest, MatchResult::matched('custom')));
+        $this->dispatch(new BlocklistMatched('scanner-paths', $serverRequest));
 
         $rows = $this->fetchAllEventRows();
         self::assertCount(1, $rows);
@@ -52,7 +53,7 @@ final class EventLogTest extends FunctionalTestCase
     {
         $serverRequest = new ServerRequest('https://example.com/search', 'GET');
 
-        $this->dispatch(new ThrottleExceeded('search-throttle', '203.0.113.10', 10, 60, 11, 42, $serverRequest, null));
+        $this->dispatch(new ThrottleExceeded('search-throttle', '203.0.113.10', 10, 60, 11, 42, $serverRequest));
 
         $rows = $this->fetchAllEventRows();
         self::assertCount(1, $rows);
@@ -69,7 +70,7 @@ final class EventLogTest extends FunctionalTestCase
     {
         $serverRequest = new ServerRequest('https://example.com/api', 'GET');
 
-        $this->dispatch(new ThrottleExceeded('api-throttle', 'secret-api-key', 10, 60, 11, 42, $serverRequest, null));
+        $this->dispatch(new ThrottleExceeded('api-throttle', 'secret-api-key', 10, 60, 11, 42, $serverRequest));
 
         $rows = $this->fetchAllEventRows();
         self::assertCount(1, $rows);
@@ -83,7 +84,7 @@ final class EventLogTest extends FunctionalTestCase
     {
         $serverRequest = new ServerRequest('https://example.com/login', 'POST');
 
-        $this->dispatch(new Fail2BanMatched('login-brute-force', '203.0.113.10', 5, 300, 3, $serverRequest, MatchResult::matched('custom')));
+        $this->dispatch(new Fail2BanMatched('login-brute-force', '203.0.113.10', 5, 300, 3, $serverRequest));
 
         $rows = $this->fetchAllEventRows();
         self::assertCount(1, $rows);
@@ -95,6 +96,44 @@ final class EventLogTest extends FunctionalTestCase
         self::assertIsString($rows[0]['meta']);
         $meta = json_decode($rows[0]['meta'], true, 512, JSON_THROW_ON_ERROR);
         self::assertSame(['threshold' => 5, 'period' => 300, 'count' => 3], $meta);
+    }
+
+    #[Test]
+    public function fail2BanBlockedEventStoresTheBanType(): void
+    {
+        if (!class_exists(Fail2BanBlocked::class)) {
+            self::markTestSkipped('Requires a phirewall version that ships Fail2BanBlocked.');
+        }
+
+        $serverRequest = new ServerRequest('https://example.com/login', 'POST');
+
+        $this->dispatch(new Fail2BanBlocked('login-brute-force', '203.0.113.10', $serverRequest));
+
+        $rows = $this->fetchAllEventRows();
+        self::assertCount(1, $rows);
+        self::assertSame('fail2ban_blocked', $rows[0]['event_type']);
+        self::assertSame('login-brute-force', $rows[0]['rule']);
+        self::assertSame(hash('sha256', '203.0.113.10'), $rows[0]['key_hash']);
+        self::assertSame('203.0.113.0', $rows[0]['key_display']);
+        self::assertSame('fail2ban', $rows[0]['ban_type']);
+    }
+
+    #[Test]
+    public function allow2BanBlockedEventStoresTheBanType(): void
+    {
+        if (!class_exists(Allow2BanBlocked::class)) {
+            self::markTestSkipped('Requires a phirewall version that ships Allow2BanBlocked.');
+        }
+
+        $serverRequest = new ServerRequest('https://example.com/form', 'POST');
+
+        $this->dispatch(new Allow2BanBlocked('form-flood', '203.0.113.10', $serverRequest));
+
+        $rows = $this->fetchAllEventRows();
+        self::assertCount(1, $rows);
+        self::assertSame('allow2ban_blocked', $rows[0]['event_type']);
+        self::assertSame('form-flood', $rows[0]['rule']);
+        self::assertSame('allow2ban', $rows[0]['ban_type']);
     }
 
     #[Test]
@@ -117,7 +156,7 @@ final class EventLogTest extends FunctionalTestCase
     #[Test]
     public function safelistEventsAreNotLoggedByDefault(): void
     {
-        $this->dispatch(new SafelistMatched('office-ips', new ServerRequest('https://example.com/', 'GET'), MatchResult::matched('custom')));
+        $this->dispatch(new SafelistMatched('office-ips', new ServerRequest('https://example.com/', 'GET')));
 
         self::assertSame([], $this->fetchAllEventRows());
     }
@@ -127,7 +166,7 @@ final class EventLogTest extends FunctionalTestCase
     {
         $this->get(ExtensionConfiguration::class)->set('firewall', ['eventLogEnabled' => '0']);
 
-        $this->dispatch(new BlocklistMatched('scanner-paths', new ServerRequest('https://example.com/', 'GET'), MatchResult::matched('custom')));
+        $this->dispatch(new BlocklistMatched('scanner-paths', new ServerRequest('https://example.com/', 'GET')));
 
         self::assertSame([], $this->fetchAllEventRows());
     }


### PR DESCRIPTION
Maps Fail2BanBlocked and Allow2BanBlocked to event log entries with ban type, statistics label and chart color. The events ship with the next phirewall release; until then the new tests skip and PHPStan flags the classes as unknown.